### PR TITLE
Add dedicated about, skills, project, showcase and contact pages

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -38,10 +38,6 @@
               <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
             </li>
             <li>
-              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
             </li>
             <li>
               <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>

--- a/public/about.html
+++ b/public/about.html
@@ -1,0 +1,177 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0070f3" />
+    <meta name="description" content="Colin McArthur Developer Portfolio Site" />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Camingo+Code:wght@400;700&display=swap" rel="stylesheet" />
+
+    <title>Colin McArthur Developer Website</title>
+  </head>
+
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 transition-colors duration-300 dark:text-white">
+    <!-- Dark mode background gradients -->
+    <div class="pointer-events-none fixed inset-0 -z-10 opacity-0 transition-opacity duration-500 dark:opacity-100">
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
+    </div>
+
+    <!-- Header -->
+    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+      <div class="container-wrapper">
+        <nav class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </a>
+          <ul class="hidden space-x-8 md:flex">
+            <li>
+              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+            </li>
+          </ul>
+          <div class="flex items-center space-x-4">
+            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+            <button id="menuToggle" class="p-2 md:hidden">
+              <div class="flex h-5 w-6 flex-col justify-between">
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+              </div>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+      <div class="container-wrapper flex h-full flex-col">
+        <div class="flex items-center justify-between py-4">
+        <a href="index.html" class="flex items-center">
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </a>
+          <button id="closeMenu" class="p-2">
+            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+          </button>
+        </div>
+        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+          <li>
+            <a href="showcase.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+          </li>
+          <li>
+            <a href="about.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+          </li>
+          <li>
+            <a href="skills.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+          </li>
+          <li>
+            <a href="projects.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+          </li>
+          <li>
+            <a href="contact.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section id="hero" class="flex min-h-screen items-center pb-16 pt-20">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="text-center lg:text-left">
+            <h1 class="mb-6 text-4xl font-bold md:text-6xl">Get to Know Colin</h1>
+            <p class="mb-8 text-xl text-gray-600 dark:text-gray-400 md:text-2xl">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec vel neque at nisl iaculis interdum.</p>
+            <div class="flex justify-center gap-4 lg:justify-start">
+              <a href="#about" class="btn btn-primary">My Story</a>
+              <a href="index.html" class="btn btn-secondary">Home</a>
+            </div>
+          </div>
+          <div class="flex justify-center">
+            <img src="./assets/images/hero/hero-image-01.png" alt="Colin" class="max-w-xs rounded-lg shadow-lg md:max-w-md" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- About Section -->
+
+    <section id="about" class="py-24">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="space-y-6 text-gray-900 dark:text-white">
+            <h2 class="section-title text-left">My Journey</h2>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris vel laoreet ipsum.</p>
+            <p>Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Integer ac neque vel lectus laoreet consequat.</p>
+            <p>Curabitur vitae magna id libero lacinia tristique sed non elit.</p>
+          </div>
+          <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+            <img src="./assets/images/about/image-1.jpg" alt="about" class="rounded-lg shadow-md" />
+            <img src="./assets/images/about/image-2.jpg" alt="about" class="rounded-lg shadow-md" />
+            <img src="./assets/images/about/image-3.jpg" alt="about" class="rounded-lg shadow-md sm:col-span-2" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="dark:bg-dark-background bg-gray-50 py-12">
+      <div class="container-wrapper">
+        <div class="mb-8 flex flex-col items-center justify-between md:flex-row">
+          <div class="mb-4 flex items-center md:mb-0">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </div>
+          <ul class="mb-0 flex flex-wrap justify-center gap-6">
+            <li>
+              <a href="showcase.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Contact</a>
+            </li>
+          </ul>
+          <div class="flex gap-4">
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-linkedin"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-twitter"></i>
+            </a>
+          </div>
+        </div>
+        <div class="text-gray-60 text-center text-sm dark:text-gray-400">
+          <p>&copy; 2025 Colin McArthur Portfio. All rights reserved</p>
+        </div>
+      </div>
+    </footer>
+    <script src="./assets/js/expressions.js"></script>
+    <script src="./assets/js/scripts.js"></script>
+  </body>
+</html>

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -39,6 +39,8 @@
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
+    --container-xs: 20rem;
+    --container-md: 28rem;
     --container-2xl: 42rem;
     --container-4xl: 56rem;
     --container-6xl: 72rem;
@@ -363,6 +365,9 @@
   .block {
     display: block;
   }
+  .contents {
+    display: contents;
+  }
   .flex {
     display: flex;
   }
@@ -473,6 +478,9 @@
   }
   .max-w-none {
     max-width: none;
+  }
+  .max-w-xs {
+    max-width: var(--container-xs);
   }
   .flex-1 {
     flex: 1;
@@ -1179,6 +1187,16 @@
       }
     }
   }
+  .sm\:col-span-2 {
+    @media (width >= 40rem) {
+      grid-column: span 2 / span 2;
+    }
+  }
+  .sm\:grid-cols-2 {
+    @media (width >= 40rem) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
   .sm\:flex-row {
     @media (width >= 40rem) {
       flex-direction: row;
@@ -1209,6 +1227,11 @@
       display: none;
     }
   }
+  .md\:max-w-md {
+    @media (width >= 48rem) {
+      max-width: var(--container-md);
+    }
+  }
   .md\:grid-cols-2 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1222,6 +1245,12 @@
   .md\:flex-row {
     @media (width >= 48rem) {
       flex-direction: row;
+    }
+  }
+  .md\:text-2xl {
+    @media (width >= 48rem) {
+      font-size: var(--text-2xl);
+      line-height: var(--tw-leading, var(--text-2xl--line-height));
     }
   }
   .md\:text-4xl {
@@ -1296,6 +1325,11 @@
       grid-template-columns: 1fr 2fr;
     }
   }
+  .lg\:justify-start {
+    @media (width >= 64rem) {
+      justify-content: flex-start;
+    }
+  }
   .lg\:px-24 {
     @media (width >= 64rem) {
       padding-inline: calc(var(--spacing) * 24);
@@ -1309,6 +1343,11 @@
   .lg\:pt-\[150px\] {
     @media (width >= 64rem) {
       padding-top: 150px;
+    }
+  }
+  .lg\:text-left {
+    @media (width >= 64rem) {
+      text-align: left;
     }
   }
   .lg\:text-right {

--- a/public/contact.html
+++ b/public/contact.html
@@ -1,0 +1,225 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0070f3" />
+    <meta name="description" content="Colin McArthur Developer Portfolio Site" />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Camingo+Code:wght@400;700&display=swap" rel="stylesheet" />
+
+    <title>Colin McArthur Developer Website</title>
+  </head>
+
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 transition-colors duration-300 dark:text-white">
+    <!-- Dark mode background gradients -->
+    <div class="pointer-events-none fixed inset-0 -z-10 opacity-0 transition-opacity duration-500 dark:opacity-100">
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
+    </div>
+
+    <!-- Header -->
+    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+      <div class="container-wrapper">
+        <nav class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </a>
+          <ul class="hidden space-x-8 md:flex">
+            <li>
+              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+            </li>
+          </ul>
+          <div class="flex items-center space-x-4">
+            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+            <button id="menuToggle" class="p-2 md:hidden">
+              <div class="flex h-5 w-6 flex-col justify-between">
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+              </div>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+      <div class="container-wrapper flex h-full flex-col">
+        <div class="flex items-center justify-between py-4">
+        <a href="index.html" class="flex items-center">
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </a>
+          <button id="closeMenu" class="p-2">
+            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+          </button>
+        </div>
+        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+          <li>
+            <a href="showcase.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+          </li>
+          <li>
+            <a href="about.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+          </li>
+          <li>
+            <a href="skills.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+          </li>
+          <li>
+            <a href="projects.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+          </li>
+          <li>
+            <a href="contact.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section id="hero" class="flex min-h-screen items-center pb-16 pt-20">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="text-center lg:text-left">
+            <h1 class="mb-6 text-4xl font-bold md:text-6xl">Get In Touch</h1>
+            <p class="mb-8 text-xl text-gray-600 dark:text-gray-400 md:text-2xl">I'd love to hear from you.</p>
+            <div class="flex justify-center gap-4 lg:justify-start">
+              <a href="#contact" class="btn btn-primary">Contact Me</a>
+              <a href="index.html" class="btn btn-secondary">Home</a>
+            </div>
+          </div>
+          <div class="flex justify-center">
+            <img src="./assets/images/hero/hero-image-01.png" alt="Colin" class="max-w-xs rounded-lg shadow-lg md:max-w-md" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+  <!-- Contact Section -->
+  <section id="contact" class="py-24 bg-gray-50 dark:bg-dark-background-secondary translate-y-4 transition-all duration-500 opacity-0">
+    <div class="container-wrapper">
+      <h2 class="section-title">Get In Touch</h2>
+      <p class="section-subtitle">
+        Interered in working together? Let's connect.
+      </p>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-12">
+        <!-- Contact Info -->
+        <div class="lg:col-span-1 grid grid-cols-1 md:grid-cols-3 lg:grid-cols-1 gap-6">
+          <!-- Email -->
+          <div class="card card-shadow text-center">
+            <div class="icon-container ">
+              <i class="fa-solid fa-envelope text-primary text-xl"></i>
+            </div>
+            <h3 class="text-xl font-bold mb-2">Email</h3>
+            <p class="text-gray-600 dark:text-gray-400">example@test.com</p>
+          </div>
+          <!-- Location -->
+          <div class="card card-shadow text-center">
+            <div class="icon-container ">
+              <i class="fa-solid fa-map-location-dot text-primary text-xl"></i>
+            </div>
+            <h3 class="text-xl font-bold mb-2">Location</h3>
+            <p class="text-gray-600 dark:text-gray-400">Over Here</p>
+          </div>
+          <!-- Social -->
+          <div class="card card-shadow text-center">
+            <div class="icon-container ">
+              <i class="fa-solid fa-globe text-primary text-xl"></i>
+            </div>
+            <h3 class="text-xl font-bold mb-2">Social</h3>
+            <div class="flex justify-center space-x-4">
+              <a href="#" class="w-10 h-10 bg-gray-100 dark:bg-dark-background-secondary rounded-full flex items-center justify-center text-gray-600 hover:text-primary dark:hover:text-primary dark:text-gray-400 transition-all duration-300">
+                <i class="fa-brands fa-github"></i>
+              </a>
+              <a href="#" class="w-10 h-10 bg-gray-100 dark:bg-dark-background-secondary rounded-full flex items-center justify-center text-gray-600 hover:text-primary dark:hover:text-primary dark:text-gray-400 transition-all duration-300">
+                <i class="fa-brands fa-linkedin"></i>
+              </a>
+              <a href="#" class="w-10 h-10 bg-gray-100 dark:bg-dark-background-secondary rounded-full flex items-center justify-center text-gray-600 hover:text-primary dark:hover:text-primary dark:text-gray-400 transition-all duration-300">
+                <i class="fa-brands fa-twitter"></i>
+              </a>
+            </div>
+          </div>
+        </div>
+        <!-- Contact Form -->
+        <div class="lg:col-span-2">
+          <form id="contactForm" action="" class="flex flex-col gap-6 card card-shadow">
+            <h3 class="text-2xl font-bold">Send me a message</h3>
+            <div class="space-y-6">
+              <label for="name" class="block text-sm font-medium text-gray-700 mb-2">Name</label>
+              <input type="text" name="name" id="name" required class="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-dark-background-secondary text-gray-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-colors outline-none">
+            </div>
+            <div class="space-y-6">
+              <label for="email" class="block text-sm font-medium text-gray-700 mb-2">Email</label>
+              <input type="email" name="email" id="email" required class="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-dark-background-secondary text-gray-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-colors outline-none">
+            </div>
+            <div class="space-y-6">
+              <label for="message" class="block text-sm font-medium text-gray-700 mb-2">Message</label>
+              <textarea type="text" name="message" id="message" rows="5" required class="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-dark-background-secondary text-gray-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-colors outline-none"></textarea>
+            </div>
+            <button type="submit" class="w-full btn-primary">Send Message</button>
+          </form>
+        </div>
+      </div>
+  </section>
+
+    <!-- Footer -->
+    <footer class="dark:bg-dark-background bg-gray-50 py-12">
+      <div class="container-wrapper">
+        <div class="mb-8 flex flex-col items-center justify-between md:flex-row">
+          <div class="mb-4 flex items-center md:mb-0">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </div>
+          <ul class="mb-0 flex flex-wrap justify-center gap-6">
+            <li>
+              <a href="showcase.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Contact</a>
+            </li>
+          </ul>
+          <div class="flex gap-4">
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-linkedin"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-twitter"></i>
+            </a>
+          </div>
+        </div>
+        <div class="text-gray-60 text-center text-sm dark:text-gray-400">
+          <p>&copy; 2025 Colin McArthur Portfio. All rights reserved</p>
+        </div>
+      </div>
+    </footer>
+    <script src="./assets/js/expressions.js"></script>
+    <script src="./assets/js/scripts.js"></script>
+  </body>
+</html>

--- a/public/contact.html
+++ b/public/contact.html
@@ -37,10 +37,6 @@
 
           <ul class="hidden space-x-8 md:flex">
             <li>
-              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
             </li>
             <li>
               <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>

--- a/public/index.html
+++ b/public/index.html
@@ -25,25 +25,25 @@
   <header class="fixed w-full top-0 z-50 bg-white/95 dark:bg-dark-background/95 backdrop-blur-sm shadow-sm transition-all duration-300">
     <div class="container-wrapper">
       <nav class="flex justify-between items-center py-4">
-        <div flex items-center>
+        <a href="index.html" class="flex items-center">
           <span class="text-xl font-extrabold">Colin McArthur</span>
           <span class="text-primary text-2xl ml-1">●</span>
-        </div>
+        </a>
         <ul class="hidden md:flex space-x-8">
           <li>
-            <a href="#features" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Showcase</a>
+            <a href="showcase.html" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Showcase</a>
           </li>
           <li>
-            <a href="#about" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">About</a>
+            <a href="about.html" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">About</a>
           </li>
           <li>
-            <a href="#skills" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Skills</a>
+            <a href="skills.html" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Skills</a>
           </li>
           <li>
-            <a href="#projects" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Projects</a>
+            <a href="projects.html" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Projects</a>
           </li>
           <li>
-            <a href="#contact" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Contact</a>
+            <a href="contact.html" class="text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Contact</a>
           </li>
         </ul>
         <div class="flex items-center space-x-4">
@@ -63,29 +63,29 @@
   <div id="mobileMenu" class="fixed inset-0 bg-white dark:bg-dark-background z-50 transform translate-x-full  duration-300 md:hidden">
     <div class="container-wrapper h-full flex flex-col">
       <div class="flex justify-between items-center py-4">
-        <div class="flex items-center">
+        <a href="index.html" class="flex items-center">
           <span class="text-xl font-extrabold">Colin McArthur</span>
           <span class="text-primary text-2xl ml-1">●</span>
-        </div>
+        </a>
         <button id="closeMenu" class="p-2">
           <i class="fa-solid fa-square-xmark text-gray-600 dark:text-gray-400 text-2xl "></i>
         </button>
       </div>
       <ul class="flex-1 flex flex-col justify-center items-center space-y-8">
         <li>
-          <a href="#features" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Showcase</a>
+          <a href="showcase.html" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Showcase</a>
         </li>
         <li>
-          <a href="#about" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">about</a>
+          <a href="about.html" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">About</a>
         </li>
         <li>
-          <a href="#skills" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Skills</a>
+          <a href="skills.html" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Skills</a>
         </li>
         <li>
-          <a href="#projects" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Projects</a>
+          <a href="projects.html" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Projects</a>
         </li>
         <li>
-          <a href="#contact" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Contact</a>
+          <a href="contact.html" class="text-2xl text-gray-700 dark:text-gray-300 hover:text-primary dark:hover:text-primary transition-colors">Contact</a>
         </li>
       </ul>
     </div>
@@ -102,9 +102,9 @@
         </h1>
         <p class="text-xl md:text-2x text-gray-600 dark:text-gray-400 mb-8">Crafting <strong>front-end solutions, solving complex technical puzzles, while providing customer service</strong> that’s as responsive as the websites I create.</p>
         <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-          <a href="#projects" class="btn btn-primary">View Projects
+          <a href="projects.html" class="btn btn-primary">View Projects
           </a>
-          <a href="#about" class="btn btn-secondary">Learn More</a>
+          <a href="about.html" class="btn btn-secondary">Learn More</a>
         </div>
         <div class="bg-gray-100 dark:bg-dark-background-secondary rounded-lg overflow-hidden shadow-lg max-w-2xl mx-auto" id="terminal-container">
           <div class="flex items-center space-x-2 p-3 bg-gray-200 dark:bg-dark-background-tertiary">
@@ -190,7 +190,7 @@
             </div>
           </div>
           <div class="flex flex-col sm:flex-row gap-4 mt-8">
-            <a href="#contact" class="btn-primary">Contact Me</a>
+            <a href="contact.html" class="btn-primary">Contact Me</a>
             <a href="#" class="btn-secondary">Download Resume</a>
           </div>
         </div>
@@ -447,19 +447,19 @@
         </div>
         <ul class="flex flex-wrap justify-center gap-6 mb-0">
           <li>
-            <a href="#features" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Showcase</a>
+            <a href="showcase.html" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Showcase</a>
           </li>
           <li>
-            <a href="#about" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">About</a>
+            <a href="about.html" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">About</a>
           </li>
           <li>
-            <a href="#skills" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Skills</a>
+            <a href="skills.html" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Skills</a>
           </li>
           <li>
-            <a href="#projects" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Projects</a>
+            <a href="projects.html" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Projects</a>
           </li>
           <li>
-            <a href="#contact" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Contact</a>
+            <a href="contact.html" class="text-gray-600 dark:text-gray-400 hover:text-primary dark:hoverLtext-primary transition-colors">Contact</a>
           </li>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -63,10 +63,6 @@
   <div id="mobileMenu" class="fixed inset-0 bg-white dark:bg-dark-background z-50 transform translate-x-full  duration-300 md:hidden">
     <div class="container-wrapper h-full flex flex-col">
       <div class="flex justify-between items-center py-4">
-        <a href="index.html" class="flex items-center">
-          <span class="text-xl font-extrabold">Colin McArthur</span>
-          <span class="text-primary text-2xl ml-1">●</span>
-        </a>
         <button id="closeMenu" class="p-2">
           <i class="fa-solid fa-square-xmark text-gray-600 dark:text-gray-400 text-2xl "></i>
         </button>

--- a/public/projects.html
+++ b/public/projects.html
@@ -37,10 +37,6 @@
 
           <ul class="hidden space-x-8 md:flex">
             <li>
-              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
             </li>
             <li>
               <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>

--- a/public/projects.html
+++ b/public/projects.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0070f3" />
+    <meta name="description" content="Colin McArthur Developer Portfolio Site" />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Camingo+Code:wght@400;700&display=swap" rel="stylesheet" />
+
+    <title>Colin McArthur Developer Website</title>
+  </head>
+
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 transition-colors duration-300 dark:text-white">
+    <!-- Dark mode background gradients -->
+    <div class="pointer-events-none fixed inset-0 -z-10 opacity-0 transition-opacity duration-500 dark:opacity-100">
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
+    </div>
+
+    <!-- Header -->
+    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+      <div class="container-wrapper">
+        <nav class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </a>
+          <ul class="hidden space-x-8 md:flex">
+            <li>
+              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+            </li>
+          </ul>
+          <div class="flex items-center space-x-4">
+            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+            <button id="menuToggle" class="p-2 md:hidden">
+              <div class="flex h-5 w-6 flex-col justify-between">
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+              </div>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+      <div class="container-wrapper flex h-full flex-col">
+        <div class="flex items-center justify-between py-4">
+        <a href="index.html" class="flex items-center">
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </a>
+          <button id="closeMenu" class="p-2">
+            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+          </button>
+        </div>
+        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+          <li>
+            <a href="showcase.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+          </li>
+          <li>
+            <a href="about.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+          </li>
+          <li>
+            <a href="skills.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+          </li>
+          <li>
+            <a href="projects.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+          </li>
+          <li>
+            <a href="contact.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section id="hero" class="flex min-h-screen items-center pb-16 pt-20">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="text-center lg:text-left">
+            <h1 class="mb-6 text-4xl font-bold md:text-6xl">Project Portfolio</h1>
+            <p class="mb-8 text-xl text-gray-600 dark:text-gray-400 md:text-2xl">Some examples of my latest projects.</p>
+            <div class="flex justify-center gap-4 lg:justify-start">
+              <a href="#projects" class="btn btn-primary">View Projects</a>
+              <a href="index.html" class="btn btn-secondary">Home</a>
+            </div>
+          </div>
+          <div class="flex justify-center">
+            <img src="./assets/images/hero/hero-image-01.png" alt="Colin" class="max-w-xs rounded-lg shadow-lg md:max-w-md" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+  <section id="projects" class="py-24 translate-y-4 transition-all duration-500 opacity-0">
+    <div class="container-wrapper">
+      <h2 class="section-title">Featured Projects</h2>
+      <p class="section-subtitle">
+        Check out some of my recent work
+      </p>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <!-- Project Card 1 -->
+        <div class="card card-hoverable card-shadow p-0">
+          <div class="h-48 relative">
+            <img src="./assets/images/design_ideas/about.jpg" alt="Crypto Platform" class="w-full h-full object-cover">
+            <div class="absolute inset-0 bg-black/20"></div>
+          </div>
+          <div class="p-6">
+            <h3 class="text-xl font-bold mb-4">Cyrpto Platform</h3>
+            <p class="text-gray-600 dark:text-gray-400">A modern cryptocurency tranding platform with real-time price tracking and portfolio management.</p>
+            <div class="flex flex-wrap gap-2 my-6">
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">HTML5</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">CSS3</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">JavaScript</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">API</span>
+
+            </div>
+            <div class="flex gap-4">
+              <a href="#" class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-blue-600 transition-colors">YouTube</a>
+              <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
+              <a href="#" class="flex items-center text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors"><i class="fa-brands fa-github mr-2"></i>Code</a>
+            </div>
+          </div>
+        </div>
+        <!-- Project Card 2 -->
+        <div class="card card-hoverable card-shadow p-0">
+          <div class="h-48 relative">
+            <img src="./assets/images/design_ideas/avatar_all.png" alt="AI Landing Page" class="w-full h-full object-cover">
+            <div class="absolute inset-0 bg-black/20"></div>
+          </div>
+          <div class="p-6">
+            <h3 class="text-xl font-bold mb-4">AI Landing Page</h3>
+            <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.</p>
+            <div class="flex flex-wrap gap-2 my-6">
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">HTML5</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">CSS3</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">JavaScript</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">API</span>
+
+            </div>
+            <div class="flex gap-4">
+              <a href="#" class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-blue-600 transition-colors">YouTube</a>
+              <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
+              <a href="#" class="flex items-center text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors"><i class="fa-brands fa-github mr-2"></i>Code</a>
+            </div>
+          </div>
+        </div>
+        <!-- Project Card 3 -->
+        <div class="card card-hoverable card-shadow p-0">
+          <div class="h-48 relative">
+            <img src="./assets/images/design_ideas/cartridge.png" alt="AI Image Detector" class="w-full h-full object-cover">
+            <div class="absolute inset-0 bg-black/20"></div>
+          </div>
+          <div class="p-6">
+            <h3 class="text-xl font-bold mb-4">AI Image Detector</h3>
+            <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit</p>
+            <div class="flex flex-wrap gap-2 my-6">
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">HTML5</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">CSS3</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">JavaScript</span>
+              <span class="px-3 py-1 bg-gray-100 dark:bg-dark-background-secondary text-gray-600 dark:text-gray-400 rounded-full text-sm">API</span>
+
+            </div>
+            <div class="flex gap-4">
+              <a href="#" class="px-4 py-2 bg-primary text-white rounded-lg hover:bg-blue-600 transition-colors">YouTube</a>
+              <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
+              <a href="#" class="flex items-center text-gray-600 dark:text-gray-400 hover:text-primary dark:hover:text-primary transition-colors"><i class="fa-brands fa-github mr-2"></i>Code</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+    <!-- Footer -->
+    <footer class="dark:bg-dark-background bg-gray-50 py-12">
+      <div class="container-wrapper">
+        <div class="mb-8 flex flex-col items-center justify-between md:flex-row">
+          <div class="mb-4 flex items-center md:mb-0">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </div>
+          <ul class="mb-0 flex flex-wrap justify-center gap-6">
+            <li>
+              <a href="showcase.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Contact</a>
+            </li>
+          </ul>
+          <div class="flex gap-4">
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-linkedin"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-twitter"></i>
+            </a>
+          </div>
+        </div>
+        <div class="text-gray-60 text-center text-sm dark:text-gray-400">
+          <p>&copy; 2025 Colin McArthur Portfio. All rights reserved</p>
+        </div>
+      </div>
+    </footer>
+    <script src="./assets/js/expressions.js"></script>
+    <script src="./assets/js/scripts.js"></script>
+  </body>
+</html>

--- a/public/showcase.html
+++ b/public/showcase.html
@@ -37,10 +37,6 @@
 
           <ul class="hidden space-x-8 md:flex">
             <li>
-              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
             </li>
             <li>
               <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>

--- a/public/showcase.html
+++ b/public/showcase.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0070f3" />
+    <meta name="description" content="Colin McArthur Developer Portfolio Site" />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Camingo+Code:wght@400;700&display=swap" rel="stylesheet" />
+
+    <title>Colin McArthur Developer Website</title>
+  </head>
+
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 transition-colors duration-300 dark:text-white">
+    <!-- Dark mode background gradients -->
+    <div class="pointer-events-none fixed inset-0 -z-10 opacity-0 transition-opacity duration-500 dark:opacity-100">
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
+    </div>
+
+    <!-- Header -->
+    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+      <div class="container-wrapper">
+        <nav class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </a>
+          <ul class="hidden space-x-8 md:flex">
+            <li>
+              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+            </li>
+          </ul>
+          <div class="flex items-center space-x-4">
+            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+            <button id="menuToggle" class="p-2 md:hidden">
+              <div class="flex h-5 w-6 flex-col justify-between">
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+              </div>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+      <div class="container-wrapper flex h-full flex-col">
+        <div class="flex items-center justify-between py-4">
+        <a href="index.html" class="flex items-center">
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </a>
+          <button id="closeMenu" class="p-2">
+            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+          </button>
+        </div>
+        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+          <li>
+            <a href="showcase.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+          </li>
+          <li>
+            <a href="about.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+          </li>
+          <li>
+            <a href="skills.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+          </li>
+          <li>
+            <a href="projects.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+          </li>
+          <li>
+            <a href="contact.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section id="hero" class="flex min-h-screen items-center pb-16 pt-20">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="text-center lg:text-left">
+            <h1 class="mb-6 text-4xl font-bold md:text-6xl">Explore My Toolkit</h1>
+            <p class="mb-8 text-xl text-gray-600 dark:text-gray-400 md:text-2xl">Discover the tools and techniques behind my builds.</p>
+            <div class="flex justify-center gap-4 lg:justify-start">
+              <a href="#features" class="btn btn-primary">See Features</a>
+              <a href="index.html" class="btn btn-secondary">Home</a>
+            </div>
+          </div>
+          <div class="flex justify-center">
+            <img src="./assets/images/hero/hero-image-01.png" alt="Colin" class="max-w-xs rounded-lg shadow-lg md:max-w-md" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+<section id="features" class="py-24 bg-gray-50 dark:bg-dark-background-secondary translate-y-4 transition-all duration-500 opacity-0">
+  <div class="container-wrapper">
+    <h2 class="section-title">What's in my Toolkit</h2>
+    <p class="section-subtitle">
+      Everything needed to build great products on the web.
+    </p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+      <!-- Feature Card 1 -->
+      <div class="card card-hoverable card-shadow">
+        <div class="card-icon">
+          <i class="fa-solid fa-paintbrush text-primary text-xl"></i>
+        </div>
+        <h3 class="card-title">Modern UI Design</h3>
+        <p class="card-body">Creating beautiful, responsive interfaces that look great on any device using the latest design trends.</p>
+      </div>
+      <!-- Feature Card 2 -->
+      <div class="card card-hoverable card-shadow">
+        <div class="card-icon">
+          <i class="fa-solid fa-code text-primary text-xl"></i>
+        </div>
+        <h3 class="card-title">Clean code</h3>
+        <p class="card-body">Writing maintainable, efficient code following best practices and modern development standards.</p>
+      </div>
+      <!-- Feature Card 3 -->
+      <div class="card card-hoverable card-shadow">
+        <div class="card-icon">
+          <i class="fa-solid fa-bolt text-primary text-xl"></i>
+        </div>
+        <h3 class="card-title">Performance Optimization</h3>
+        <p class="card-body">Ensuring fast load times and smooth expereinces through efficient code and asset optimiation.</p>
+      </div>
+      <!-- Feature Card 4 -->
+      <div class="card card-hoverable card-shadow">
+        <div class="card-icon">
+          <i class="fa-solid fa-mobile-alt text-primary text-xl"></i>
+        </div>
+        <h3 class="card-title">Responsive Development</h3>
+        <p class="card-body">Building websites that work flawlessly across all screen sizes, from phone to large displays.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+    <!-- Footer -->
+    <footer class="dark:bg-dark-background bg-gray-50 py-12">
+      <div class="container-wrapper">
+        <div class="mb-8 flex flex-col items-center justify-between md:flex-row">
+          <div class="mb-4 flex items-center md:mb-0">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </div>
+          <ul class="mb-0 flex flex-wrap justify-center gap-6">
+            <li>
+              <a href="showcase.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Contact</a>
+            </li>
+          </ul>
+          <div class="flex gap-4">
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-linkedin"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-twitter"></i>
+            </a>
+          </div>
+        </div>
+        <div class="text-gray-60 text-center text-sm dark:text-gray-400">
+          <p>&copy; 2025 Colin McArthur Portfio. All rights reserved</p>
+        </div>
+      </div>
+    </footer>
+    <script src="./assets/js/expressions.js"></script>
+    <script src="./assets/js/scripts.js"></script>
+  </body>
+</html>

--- a/public/skills.html
+++ b/public/skills.html
@@ -1,0 +1,229 @@
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#0070f3" />
+    <meta name="description" content="Colin McArthur Developer Portfolio Site" />
+    <link rel="stylesheet" href="./assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Camingo+Code:wght@400;700&display=swap" rel="stylesheet" />
+
+    <title>Colin McArthur Developer Website</title>
+  </head>
+
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 transition-colors duration-300 dark:text-white">
+    <!-- Dark mode background gradients -->
+    <div class="pointer-events-none fixed inset-0 -z-10 opacity-0 transition-opacity duration-500 dark:opacity-100">
+      <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
+    </div>
+
+    <!-- Header -->
+    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+      <div class="container-wrapper">
+        <nav class="flex items-center justify-between py-4">
+          <a href="index.html" class="flex items-center">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </a>
+          <ul class="hidden space-x-8 md:flex">
+            <li>
+              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+            </li>
+          </ul>
+          <div class="flex items-center space-x-4">
+            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+            <button id="menuToggle" class="p-2 md:hidden">
+              <div class="flex h-5 w-6 flex-col justify-between">
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+              </div>
+            </button>
+          </div>
+        </nav>
+      </div>
+    </header>
+    <!-- Mobile Menu -->
+    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+      <div class="container-wrapper flex h-full flex-col">
+        <div class="flex items-center justify-between py-4">
+        <a href="index.html" class="flex items-center">
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </a>
+          <button id="closeMenu" class="p-2">
+            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+          </button>
+        </div>
+        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+          <li>
+            <a href="showcase.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
+          </li>
+          <li>
+            <a href="about.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
+          </li>
+          <li>
+            <a href="skills.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>
+          </li>
+          <li>
+            <a href="projects.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Projects</a>
+          </li>
+          <li>
+            <a href="contact.html" class="text-2xl text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Contact</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Hero Section -->
+    <section id="hero" class="flex min-h-screen items-center pb-16 pt-20">
+      <div class="container-wrapper">
+        <div class="grid grid-cols-1 items-center gap-16 lg:grid-cols-2">
+          <div class="text-center lg:text-left">
+            <h1 class="mb-6 text-4xl font-bold md:text-6xl">My Skill Set</h1>
+            <p class="mb-8 text-xl text-gray-600 dark:text-gray-400 md:text-2xl">A deeper look at my core competencies.</p>
+            <div class="flex justify-center gap-4 lg:justify-start">
+              <a href="#skills" class="btn btn-primary">View Skills</a>
+              <a href="index.html" class="btn btn-secondary">Home</a>
+            </div>
+          </div>
+          <div class="flex justify-center">
+            <img src="./assets/images/hero/hero-image-01.png" alt="Colin" class="max-w-xs rounded-lg shadow-lg md:max-w-md" />
+          </div>
+        </div>
+      </div>
+    </section>
+
+
+  <section id="skills" class="py-24 bg-gray-50 dark:bg-dark-background-secondary translate-y-4 transition-all duratio-500 opacity-0">
+    <div class="container-wrapper">
+      <h2 class="section-title">My Skills</h2>
+      <p class="section-subtitle">Technologies and tools I use to bring products to life.</p>
+
+
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <!-- Skills Card 1 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-html5 text-red-500 text-3xl"></i>
+          </div>
+          <h3 class="card-title">HTML5</h3>
+          <div class="progress-bar">
+            <div class="w-[95%] progress-bar-fill"></div>
+          </div>
+        </div>
+        <!-- Skills Card 2 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-css3 text-blue-500 text-3xl"></i>
+          </div>
+          <h3 class="card-title">CSS3</h3>
+          <div class="progress-bar">
+            <div class="w-[90%] progress-bar-fill"></div>
+          </div>
+        </div>
+        <!-- Skills Card 3 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-js text-yellow-500 text-3xl"></i>
+          </div>
+          <h3 class="card-title">JavaScript</h3>
+          <div class="progress-bar">
+            <div class="w-[85%] progress-bar-fill"></div>
+          </div>
+        </div>
+        <!-- Skills Card 4 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-react text-blue-400 text-3xl"></i>
+          </div>
+          <h3 class="card-title">React</h3>
+          <div class="progress-bar">
+            <div class="w-[95%] progress-bar-fill"></div>
+          </div>
+        </div>
+        <!-- Skills Card 5 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-git-alt text-orange-500 text-3xl"></i>
+          </div>
+          <h3 class="card-title">Git</h3>
+          <div class="progress-bar">
+            <div class="w-[85%] progress-bar-fill"></div>
+          </div>
+        </div>
+        <!-- Skills Card 6 -->
+        <div class="card">
+          <div class="card-icon">
+            <i class="fa-brands fa-desktop text-purple-500 text-3xl"></i>
+          </div>
+          <h3 class="card-title">Responsive Design</h3>
+          <div class="progress-bar">
+            <div class="w-[85%] progress-bar-fill"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+    <!-- Footer -->
+    <footer class="dark:bg-dark-background bg-gray-50 py-12">
+      <div class="container-wrapper">
+        <div class="mb-8 flex flex-col items-center justify-between md:flex-row">
+          <div class="mb-4 flex items-center md:mb-0">
+            <span class="text-xl font-extrabold">Colin McArthur</span>
+            <span class="ml-1 text-2xl text-primary">●</span>
+          </div>
+          <ul class="mb-0 flex flex-wrap justify-center gap-6">
+            <li>
+              <a href="showcase.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Showcase</a>
+            </li>
+            <li>
+              <a href="about.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">About</a>
+            </li>
+            <li>
+              <a href="skills.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Skills</a>
+            </li>
+            <li>
+              <a href="projects.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Projects</a>
+            </li>
+            <li>
+              <a href="contact.html" class="dark:hoverLtext-primary text-gray-600 transition-colors hover:text-primary dark:text-gray-400">Contact</a>
+            </li>
+          </ul>
+          <div class="flex gap-4">
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-github"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-linkedin"></i>
+            </a>
+            <a href="#" class="text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+              <i class="fa-brands fa-twitter"></i>
+            </a>
+          </div>
+        </div>
+        <div class="text-gray-60 text-center text-sm dark:text-gray-400">
+          <p>&copy; 2025 Colin McArthur Portfio. All rights reserved</p>
+        </div>
+      </div>
+    </footer>
+    <script src="./assets/js/expressions.js"></script>
+    <script src="./assets/js/scripts.js"></script>
+  </body>
+</html>

--- a/public/skills.html
+++ b/public/skills.html
@@ -37,10 +37,6 @@
 
           <ul class="hidden space-x-8 md:flex">
             <li>
-              <a href="showcase.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">About</a>
             </li>
             <li>
               <a href="skills.html" class="text-gray-700 transition-colors hover:text-primary dark:text-gray-300 dark:hover:text-primary">Skills</a>


### PR DESCRIPTION
## Summary
- create standalone pages for Showcase, Skills, Projects and Contact
- update navigation links across site
- remove extra contact form from `about.html`
- update about page hero and add gallery
- link the logo in the header and mobile menus back to the homepage

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68465c5f99548326abddd481540240fc