### PR TITLE
Refactor header to reusable component

### DIFF
--- a/public/about.html
+++ b/public/about.html
@@ -28,83 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="index.html" class="mobile-nav-link">Home</a>
-            </li>
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full ope-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
@@ -187,6 +112,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>

--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -8,19 +8,86 @@ document.addEventListener("DOMContentLoaded", () => {
     })
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;
-
-      // Add event listeners for mobile menu toggle
-      const menuToggle = document.getElementById("menuToggle");
-      const closeMenu = document.getElementById("closeMenu");
-      const mobileMenu = document.getElementById("mobileMenu");
-
-      menuToggle?.addEventListener("click", () => {
-        mobileMenu.classList.remove("translate-x-full");
-      });
-
-      closeMenu?.addEventListener("click", () => {
-        mobileMenu.classList.add("translate-x-full");
-      });
+      initMenu();
     })
     .catch((error) => console.error("Error loading menu:", error));
+
+  function initMenu() {
+    // === Theme Toggle ===
+    const htmlEl = document.documentElement;
+    const themeToggle = document.getElementById("themeToggle");
+    const icon = themeToggle?.querySelector("i");
+    const themeMeta = document.querySelector('meta[name="theme-color"]');
+
+    const setTheme = (isDark) => {
+      htmlEl.classList.toggle("dark", isDark);
+      localStorage.setItem("theme", isDark ? "dark" : "light");
+      themeMeta?.setAttribute("content", isDark ? "#000000" : "#0070f3");
+      icon?.classList.replace(isDark ? "fa-moon" : "fa-sun", isDark ? "fa-sun" : "fa-moon");
+      themeToggle?.setAttribute(
+        "aria-label",
+        isDark ? "Switch to light mode" : "Switch to dark mode"
+      );
+    };
+
+    const savedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+      setTheme(true);
+    }
+
+    themeToggle?.addEventListener("click", () => {
+      const isDark = !htmlEl.classList.contains("dark");
+      setTheme(isDark);
+    });
+
+    // === Mobile navigation toggle ===
+    const menuToggle = document.getElementById("menuToggle");
+    const closeMenu = document.getElementById("closeMenu");
+    const mobileMenu = document.getElementById("mobileMenu");
+    const header = document.querySelector("header");
+
+    if (menuToggle && closeMenu && mobileMenu) {
+      menuToggle.addEventListener("click", () => {
+        mobileMenu.classList.remove("translate-x-full");
+        document.body.classList.add("overflow-hidden");
+      });
+
+      closeMenu.addEventListener("click", () => {
+        mobileMenu.classList.add("translate-x-full");
+        document.body.classList.remove("overflow-hidden");
+      });
+
+      const mobileLinks = mobileMenu.querySelectorAll("a");
+      mobileLinks.forEach((link) => {
+        link.addEventListener("click", () => {
+          mobileMenu.classList.add("translate-x-full");
+          document.body.classList.remove("overflow-hidden");
+        });
+      });
+    }
+
+    // === Smooth Scrolling for Anchor Links ===
+    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
+      anchor.addEventListener("click", function (e) {
+        const targetElement = document.querySelector(this.getAttribute("href"));
+        if (targetElement) {
+          e.preventDefault();
+          const headerHeight = header?.offsetHeight || 0;
+          const targetPosition =
+            targetElement.getBoundingClientRect().top +
+            window.pageYOffset -
+            headerHeight;
+          window.scrollTo({ top: targetPosition, behavior: "smooth" });
+        }
+      });
+    });
+
+    // === Add Header Shadow When Scrolling ===
+    window.addEventListener("scroll", () => {
+      if (header) {
+        header.classList.toggle("shadow-md", window.scrollY > 0);
+      }
+    });
+  }
 });

--- a/public/assets/js/scripts.js
+++ b/public/assets/js/scripts.js
@@ -1,76 +1,11 @@
 document.addEventListener("DOMContentLoaded", function () {
   // === Cache DOM elements ===
-  const themeToggle = document.getElementById("themeToggle");
-  const html = document.documentElement;
-  const icon = themeToggle?.querySelector("i");
-  const themeMeta = document.querySelector('meta[name="theme-color"]');
   const contactForm = document.getElementById("contactForm");
-  const header = document.querySelector("header");
   const sections = document.querySelectorAll("section");
 
   const terminalContainer = document.getElementById("terminal-container");
   const terminalContent = document.querySelector(".terminal-content");
   const commandSpan = document.querySelector(".command-text");
-
-  // === Theme Toggle ===
-  const setTheme = (isDark) => {
-    html.classList.toggle("dark", isDark);
-    localStorage.setItem("theme", isDark ? "dark" : "light");
-    themeMeta?.setAttribute("content", isDark ? "#000000" : "#0070f3");
-    icon?.classList.replace(isDark ? "fa-moon" : "fa-sun", isDark ? "fa-sun" : "fa-moon");
-    themeToggle?.setAttribute("aria-label", isDark ? "Switch to light mode" : "Switch to dark mode");
-  };
-
-  const savedTheme = localStorage.getItem("theme");
-  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-  if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
-    setTheme(true);
-  }
-
-  themeToggle?.addEventListener("click", () => {
-    const isDark = !html.classList.contains("dark");
-    setTheme(isDark);
-  });
-
-  // Mobile navigation toggle
-  const menuToggle = document.getElementById("menuToggle");
-  const closeMenu = document.getElementById("closeMenu");
-  const mobileMenu = document.getElementById("mobileMenu");
-
-  if (menuToggle && closeMenu && mobileMenu) {
-    menuToggle.addEventListener("click", function () {
-      mobileMenu.classList.remove("translate-x-full");
-      document.body.classList.add("overflow-hidden");
-    });
-
-    closeMenu.addEventListener("click", function () {
-      mobileMenu.classList.add("translate-x-full");
-      document.body.classList.remove("overflow-hidden");
-    });
-
-    // === Smooth Scrolling for Anchor Links ===
-    document.querySelectorAll('a[href^="#"]').forEach((anchor) => {
-      anchor.addEventListener("click", function (e) {
-        e.preventDefault();
-        const targetElement = document.querySelector(this.getAttribute("href"));
-        if (targetElement) {
-          const headerHeight = header?.offsetHeight || 0;
-          const targetPosition = targetElement.getBoundingClientRect().top + window.pageYOffset - headerHeight;
-
-          window.scrollTo({ top: targetPosition, behavior: "smooth" });
-        }
-      });
-    });
-
-    // Close Mobile Menu
-    const mobileLinks = mobileMenu.querySelectorAll("a");
-    mobileLinks.forEach((link) => {
-      link.addEventListener("click", function () {
-        mobileMenu.classList.add("translate-x-full");
-        document.body.classList.remove("overflow-hidden");
-      });
-    });
-  }
 
   // === Contact Form Handling ===
   contactForm?.addEventListener("submit", function (e) {
@@ -115,13 +50,6 @@ document.addEventListener("DOMContentLoaded", function () {
   sections.forEach((section) => {
     section.classList.add("opacity-0", "translate-y-4");
     observer.observe(section);
-  });
-
-  // === Add Header Shadow When Scrolling ===
-  window.addEventListener("scroll", () => {
-    if (header) {
-      header.classList.toggle("shadow-md", window.scrollY > 0);
-    }
   });
 
   // === Terminal Typing Animation ===

--- a/public/components/menu.html
+++ b/public/components/menu.html
@@ -1,0 +1,73 @@
+<header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
+  <div class="container-wrapper">
+    <nav class="navbar">
+      <a href="index.html">
+        <div flex items-center>
+          <span class="text-xl font-extrabold">Colin McArthur</span>
+          <span class="ml-1 text-2xl text-primary">●</span>
+        </div>
+      </a>
+      <ul class="hidden space-x-8 md:flex">
+        <li>
+          <a href="showcase.html" class="nav-link">Showcase</a>
+        </li>
+        <li>
+          <a href="about.html" class="nav-link">About</a>
+        </li>
+        <li>
+          <a href="skills.html" class="nav-link">Skills</a>
+        </li>
+        <li>
+          <a href="projects.html" class="nav-link">Projects</a>
+        </li>
+        <li>
+          <a href="contact.html" class="nav-link">Contact</a>
+        </li>
+      </ul>
+      <div class="flex items-center space-x-4">
+        <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
+        <button id="menuToggle" class="p-2 md:hidden">
+          <div class="flex h-5 w-6 flex-col justify-between">
+            <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+            <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+            <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
+          </div>
+        </button>
+      </div>
+    </nav>
+  </div>
+</header>
+<!-- Mobile Menu -->
+<div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
+  <div class="container-wrapper flex h-full flex-col">
+    <div class="navbar">
+      <div class="flex items-center">
+        <span class="text-xl font-extrabold">Colin McArthur</span>
+        <span class="ml-1 text-2xl text-primary">●</span>
+      </div>
+      <button id="closeMenu" class="p-2">
+        <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
+      </button>
+    </div>
+    <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
+      <li>
+        <a href="index.html" class="mobile-nav-link">Home</a>
+      </li>
+      <li>
+        <a href="showcase.html" class="mobile-nav-link">Showcase</a>
+      </li>
+      <li>
+        <a href="about.html" class="mobile-nav-link">About</a>
+      </li>
+      <li>
+        <a href="skills.html" class="mobile-nav-link">Skills</a>
+      </li>
+      <li>
+        <a href="projects.html" class="mobile-nav-link">Projects</a>
+      </li>
+      <li>
+        <a href="contact.html" class="mobile-nav-link">Contact</a>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/public/contact.html
+++ b/public/contact.html
@@ -28,80 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
@@ -230,6 +158,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -28,80 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section relative overflow-hidden">
@@ -503,6 +431,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>

--- a/public/projects.html
+++ b/public/projects.html
@@ -28,80 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
@@ -248,6 +176,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>

--- a/public/showcase.html
+++ b/public/showcase.html
@@ -28,80 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
@@ -206,6 +134,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>

--- a/public/skills.html
+++ b/public/skills.html
@@ -28,80 +28,8 @@
       <div class="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-secondary/10"></div>
     </div>
 
-    <!-- Header -->
-    <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
-      <div class="container-wrapper">
-        <nav class="navbar">
-          <a href="index.html">
-            <div flex items-center>
-              <span class="text-xl font-extrabold">Colin McArthur</span>
-              <span class="ml-1 text-2xl text-primary">●</span>
-            </div>
-          </a>
-          <ul class="hidden space-x-8 md:flex">
-            <li>
-              <a href="showcase.html" class="nav-link">Showcase</a>
-            </li>
-            <li>
-              <a href="about.html" class="nav-link">About</a>
-            </li>
-            <li>
-              <a href="skills.html" class="nav-link">Skills</a>
-            </li>
-            <li>
-              <a href="projects.html" class="nav-link">Projects</a>
-            </li>
-            <li>
-              <a href="contact.html" class="nav-link">Contact</a>
-            </li>
-          </ul>
-          <div class="flex items-center space-x-4">
-            <button id="themeToggle" class=""><i class="fa-solid fa-moon text-gray-600 dark:text-gray-400"></i></button>
-            <button id="menuToggle" class="p-2 md:hidden">
-              <div class="flex h-5 w-6 flex-col justify-between">
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-                <span class="h-0.5 w-full bg-gray-600 transition-all dark:bg-gray-400"></span>
-              </div>
-            </button>
-          </div>
-        </nav>
-      </div>
-    </header>
-    <!-- Mobile Menu -->
-    <div id="mobileMenu" class="dark:bg-dark-background fixed inset-0 z-50 translate-x-full transform bg-white duration-300 md:hidden">
-      <div class="container-wrapper flex h-full flex-col">
-        <div class="navbar">
-          <div class="flex items-center">
-            <span class="text-xl font-extrabold">Colin McArthur</span>
-            <span class="ml-1 text-2xl text-primary">●</span>
-          </div>
-          <button id="closeMenu" class="p-2">
-            <i class="fa-solid fa-square-xmark text-2xl text-gray-600 dark:text-gray-400"></i>
-          </button>
-        </div>
-        <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
-          <li>
-            <a href="index.html" class="mobile-nav-link">Home</a>
-          </li>
-          <li>
-            <a href="showcase.html" class="mobile-nav-link">Showcase</a>
-          </li>
-          <li>
-            <a href="about.html" class="mobile-nav-link">About</a>
-          </li>
-          <li>
-            <a href="skills.html" class="mobile-nav-link">Skills</a>
-          </li>
-          <li>
-            <a href="projects.html" class="mobile-nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="contact.html" class="mobile-nav-link">Contact</a>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <!-- Header loaded via JS -->
+    <div id="menu-container"></div>
 
     <!-- Hero Section -->
     <section id="hero" class="hero-section">
@@ -234,6 +162,7 @@
         </div>
       </div>
     </footer>
+    <script src="./assets/js/components/header.js"></script>
     <script src="./assets/js/expressions.js"></script>
     <script src="./assets/js/scripts.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- extract shared header markup into `components/menu.html`
- load new menu component via `header.js`
- initialize theme toggle and mobile menu in `header.js`
- streamline `scripts.js`
- update all pages to use menu component and include `header.js`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684e4d5c64bc8326bb8273b7cc22fa07