### PR TITLE
Fix GH Pages deploy conflict

### DIFF
--- a/.github/workflows/main-site.yml
+++ b/.github/workflows/main-site.yml
@@ -26,3 +26,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
           publish_branch: gh-pages
+          force: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -35,6 +35,7 @@ jobs:
           destination_dir: previews/pr-${{ env.PR_NUM }}
           publish_branch: gh-pages
           keep_files: true
+          force: true
 
       - name: Comment preview URL on PR
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
## Summary
- force push when deploying to `gh-pages` for main site
- force push when deploying PR previews

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68539ffba6488326b20b7a6b127d797e