### PR TITLE
Add dynamic skill line counting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css && rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js",
+    "build": "node scripts/updateSkillCounts.js && tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css && rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js",
     "watch": "rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js && tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css --watch"
   },
   "keywords": [],

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -50,6 +50,8 @@
   --color-gray-900: oklch(21% 0.034 264.665);
   --color-neutral-200: oklch(92.2% 0 0);
   --color-neutral-300: oklch(87% 0 0);
+  --color-neutral-400: oklch(70.8% 0 0);
+  --color-neutral-500: oklch(55.6% 0 0);
   --color-neutral-800: oklch(26.9% 0 0);
   --color-black: #000;
   --color-white: #fff;
@@ -298,6 +300,9 @@
   }
   .my-6 {
     margin-block: calc(var(--spacing) * 6);
+  }
+  .mt-1 {
+    margin-top: calc(var(--spacing) * 1);
   }
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
@@ -846,6 +851,10 @@
     font-size: var(--text-xl);
     line-height: var(--tw-leading, var(--text-xl--line-height));
   }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
@@ -881,6 +890,9 @@
   }
   .text-neutral-300 {
     color: var(--color-neutral-300);
+  }
+  .text-neutral-400 {
+    color: var(--color-neutral-400);
   }
   .text-orange-500 {
     color: var(--color-orange-500);
@@ -1129,6 +1141,11 @@
   .dark\:text-neutral-200 {
     &:where(.dark, .dark *) {
       color: var(--color-neutral-200);
+    }
+  }
+  .dark\:text-neutral-500 {
+    &:where(.dark, .dark *) {
+      color: var(--color-neutral-500);
     }
   }
   .dark\:text-white {

--- a/public/assets/js/skills.js
+++ b/public/assets/js/skills.js
@@ -13,8 +13,12 @@ document.addEventListener("DOMContentLoaded", () => {
         if (card) {
           const bar = card.querySelector(".progress-bar-fill");
           const label = card.querySelector(".progress-percent");
+          const lines = card.querySelector(".lines-count");
           if (bar) {
             bar.style.width = `${percent}%`;
+          }
+          if (lines) {
+            lines.textContent = `${count} lines`;
           }
           if (label) {
             label.textContent = `${percent}%`;

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -1,8 +1,9 @@
 {
-  "HTML": 1000,
-  "CSS": 750,
-  "JavaScript": 500,
-  "PHP": 200,
-  "MySQL": 15,
-  "Git": 300
+  "HTML": 1405,
+  "CSS": 386,
+  "JavaScript": 418,
+  "PHP": 0,
+  "MySQL": 0,
+  "React": 0,
+  "Git": 0
 }

--- a/public/index.html
+++ b/public/index.html
@@ -210,6 +210,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
           <!-- Skills Card 2 -->
           <div class="card" data-skill="CSS">
@@ -224,6 +225,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
           <!-- Skills Card 3 -->
           <div class="card" data-skill="JavaScript">
@@ -238,6 +240,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
 
           <!-- Skills Card 4 -->
@@ -253,6 +256,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
           <!-- Skills Card 5 -->
           <div class="card" data-skill="MySQL">
@@ -267,6 +271,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
 
           <!-- Skills Card 6 -->
@@ -282,6 +287,7 @@
               </div>
               <span class="progress-percent text-sm text-neutral-300 dark:text-neutral-200 font-mono w-10 text-right">0%</span>
             </div>
+            <p class="lines-count text-xs text-neutral-400 dark:text-neutral-500 font-mono mt-1">0 lines</p>
           </div>
         </div>
       </div>

--- a/scripts/updateSkillCounts.js
+++ b/scripts/updateSkillCounts.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+const skillExtensions = {
+  HTML: ['.html'],
+  CSS: ['.css'],
+  JavaScript: ['.js'],
+  PHP: ['.php'],
+  MySQL: ['.sql'],
+  React: ['.jsx', '.tsx'],
+  Git: []
+};
+
+const ignoreDirs = ['node_modules', '.git', 'public/assets', 'public/data', 'scripts'];
+
+function walkDir(dir, cb) {
+  fs.readdirSync(dir).forEach((file) => {
+    const fullPath = path.join(dir, file);
+    const stat = fs.statSync(fullPath);
+    const base = path.basename(fullPath);
+    if (stat.isDirectory()) {
+      if (!ignoreDirs.some((d) => fullPath.includes(d))) {
+        walkDir(fullPath, cb);
+      }
+    } else {
+      cb(fullPath);
+    }
+  });
+}
+
+function countLines(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/).length;
+}
+
+const counts = {};
+Object.keys(skillExtensions).forEach((k) => (counts[k] = 0));
+
+walkDir('.', (file) => {
+  const ext = path.extname(file);
+  for (const [skill, extensions] of Object.entries(skillExtensions)) {
+    if (extensions.includes(ext)) {
+      counts[skill] += countLines(file);
+      break;
+    }
+  }
+});
+
+fs.writeFileSync('public/data/skills.json', JSON.stringify(counts, null, 2));
+console.log('Updated skills.json', counts);

--- a/src/js/skills.js
+++ b/src/js/skills.js
@@ -13,8 +13,12 @@ document.addEventListener("DOMContentLoaded", () => {
         if (card) {
           const bar = card.querySelector(".progress-bar-fill");
           const label = card.querySelector(".progress-percent");
+          const lines = card.querySelector(".lines-count");
           if (bar) {
             bar.style.width = `${percent}%`;
+          }
+          if (lines) {
+            lines.textContent = `${count} lines`;
           }
           if (label) {
             label.textContent = `${percent}%`;


### PR DESCRIPTION
## Summary
- dynamically count code lines by language during build
- display code line totals in skills cards
- generate latest counts for skills
- include new updateSkillCounts build step

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854e60ce6d8832685c13cb1de829727