### PR TITLE
Remove unsupported webp images

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -185,11 +185,11 @@
               <div class="relative z-10 inline-block pt-11 lg:pt-0">
                 <div class="pb-0 pl-6 pr-6 pt-6">
                   <div class="avatar-container">
-                    <img class="max-w-none" id="head" src="./assets/images/sprites/colin_avatar/Head/head_forward_1.png" alt="Avatar" />
-                    <img class="avatar-layer" id="brows" src="./assets/images/sprites/colin_avatar/Brows/brows_neutral.png" alt="Avatar" />
-                    <img class="avatar-layer" id="eyes" src="./assets/images/sprites/colin_avatar/Eyes/open_forward.png" alt="Avatar" />
-                    <img class="avatar-layer" id="glasses" src="./assets/images/sprites/colin_avatar/Glasses/glasses.png" alt="Avatar" />
-                    <img class="avatar-layer" id="mouth" src="./assets/images/sprites/colin_avatar/Mouth/smile.png" alt="Avatar" />
+                    <img class="max-w-none" id="head" src="./assets/images/sprites/colin_avatar/Head/head_forward_1.png" alt="Avatar" loading="lazy" width="476" height="488" />
+                    <img class="avatar-layer" id="brows" src="./assets/images/sprites/colin_avatar/Brows/brows_neutral.png" alt="Avatar" loading="lazy" width="176" height="13" />
+                    <img class="avatar-layer" id="eyes" src="./assets/images/sprites/colin_avatar/Eyes/open_forward.png" alt="Avatar" loading="lazy" width="176" height="26" />
+                    <img class="avatar-layer" id="glasses" src="./assets/images/sprites/colin_avatar/Glasses/glasses.png" alt="Avatar" loading="lazy" width="276" height="76" />
+                    <img class="avatar-layer" id="mouth" src="./assets/images/sprites/colin_avatar/Mouth/smile.png" alt="Avatar" loading="lazy" width="126" height="26" />
                   </div>
                 </div>
               </div>
@@ -313,7 +313,7 @@
           <!-- Project Card 1 -->
           <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
             <div class="relative h-48">
-              <img src="./assets/images/design_ideas/about.jpg" alt="Crypto Platform" class="h-full w-full object-cover" />
+              <img src="./assets/images/design_ideas/about.jpg" loading="lazy" width="736" height="552" alt="Crypto Platform" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
@@ -338,7 +338,7 @@
           <!-- Project Card 2 -->
           <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
             <div class="relative h-48">
-              <img src="./assets/images/design_ideas/avatar_all.png" alt="AI Landing Page" class="h-full w-full object-cover" />
+              <img src="./assets/images/design_ideas/avatar_all.png" loading="lazy" width="997" height="669" alt="AI Landing Page" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
@@ -363,7 +363,7 @@
           <!-- Project Card 3 -->
           <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
             <div class="relative h-48">
-              <img src="./assets/images/design_ideas/cartridge.png" alt="AI Image Detector" class="h-full w-full object-cover" />
+              <img src="./assets/images/design_ideas/cartridge.png" loading="lazy" width="1972" height="1970" alt="AI Image Detector" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">

--- a/public/pages/about.html
+++ b/public/pages/about.html
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="flex justify-center">
-            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" />
+            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" loading="lazy" width="491" height="515" />
           </div>
         </div>
       </div>
@@ -72,9 +72,9 @@
             <p>Curabitur vitae magna id libero lacinia tristique sed non elit.</p>
           </div>
           <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <img src="../assets/images/about/image-1.jpg" alt="about" class="rounded-lg shadow-md" />
-            <img src="../assets/images/about/image-2.jpg" alt="about" class="rounded-lg shadow-md" />
-            <img src="../assets/images/about/image-3.jpg" alt="about" class="rounded-lg shadow-md sm:col-span-2" />
+            <img src="../assets/images/about/image-1.jpg" alt="about" class="rounded-lg shadow-md" loading="lazy" width="270" height="320" />
+            <img src="../assets/images/about/image-2.jpg" alt="about" class="rounded-lg shadow-md" loading="lazy" width="270" height="320" />
+            <img src="../assets/images/about/image-3.jpg" alt="about" class="rounded-lg shadow-md sm:col-span-2" loading="lazy" width="270" height="400" />
           </div>
         </div>
       </div>

--- a/public/pages/contact.html
+++ b/public/pages/contact.html
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="flex justify-center">
-            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" />
+            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" loading="lazy" width="491" height="515" />
           </div>
         </div>
       </div>

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="flex justify-center">
-            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" />
+            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" loading="lazy" width="491" height="515" />
           </div>
         </div>
       </div>
@@ -68,7 +68,7 @@
           <!-- Project Card 1 -->
           <div class="card card-hoverable card-shadow p-0">
             <div class="relative h-48">
-              <img src="../assets/images/design_ideas/about.jpg" alt="Crypto Platform" class="h-full w-full object-cover" />
+              <img src="../assets/images/design_ideas/about.jpg" loading="lazy" width="736" height="552" alt="Crypto Platform" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
@@ -93,7 +93,7 @@
           <!-- Project Card 2 -->
           <div class="card card-hoverable card-shadow p-0">
             <div class="relative h-48">
-              <img src="../assets/images/design_ideas/avatar_all.png" alt="AI Landing Page" class="h-full w-full object-cover" />
+              <img src="../assets/images/design_ideas/avatar_all.png" loading="lazy" width="997" height="669" alt="AI Landing Page" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
@@ -118,7 +118,7 @@
           <!-- Project Card 3 -->
           <div class="card card-hoverable card-shadow p-0">
             <div class="relative h-48">
-              <img src="../assets/images/design_ideas/cartridge.png" alt="AI Image Detector" class="h-full w-full object-cover" />
+              <img src="../assets/images/design_ideas/cartridge.png" loading="lazy" width="1972" height="1970" alt="AI Image Detector" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">

--- a/public/pages/showcase.html
+++ b/public/pages/showcase.html
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="flex justify-center">
-            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" />
+            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" loading="lazy" width="491" height="515" />
           </div>
         </div>
       </div>

--- a/public/pages/skills.html
+++ b/public/pages/skills.html
@@ -54,7 +54,7 @@
             </div>
           </div>
           <div class="flex justify-center">
-            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" />
+            <img src="../assets/images/hero/hero-image-01.png" alt="Colin" class="hero-img" loading="lazy" width="491" height="515" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove newly added WebP files
- keep lazy loading & dimension attributes for images
- revert HTML references to PNG/JPG hero images

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855b0caaca0832682e7ca2f666ec2c0