### PR TITLE
Fix HTML class attribute in menu

### DIFF
--- a/public/components/menu.html
+++ b/public/components/menu.html
@@ -2,7 +2,7 @@
   <div class="container-wrapper">
     <nav class="navbar">
       <a href="index.html">
-        <div flex items-center>
+        <div class="flex items-center">
           <span class="text-xl font-extrabold">Colin McArthur</span>
           <span class="ml-1 text-2xl text-primary">●</span>
         </div>


### PR DESCRIPTION
## Summary
- fix navigation markup by using `class` attribute for flex container

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855b54547bc83269f6e97304ec09d2b