### PR TITLE
Run skill counter automatically

### DIFF
--- a/.github/workflows/main-site.yml
+++ b/.github/workflows/main-site.yml
@@ -11,11 +11,20 @@ jobs:
     permissions:
       contents: write
 
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Optional: If you have a build step (npm run build), it goes here.
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build
 
       - name: Create .nojekyll
         run: touch ./public/.nojekyll

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "node scripts/updateSkillCounts.js && tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css && rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js",
-    "watch": "rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js && tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css --watch"
+    "watch": "node scripts/updateSkillCounts.js && rm -rf ./public/assets/js && cp -r ./src/js ./public/assets/js && tailwindcss -i ./src/styles/tailwind.css -o ./public/assets/css/style.css --watch"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- run `npm run build` in GitHub actions before deployment
- update the `watch` script to run the skill counter

## Testing
- `npm run build`
- `npm run watch`

------
https://chatgpt.com/codex/tasks/task_e_68577bc8ed188326aa8c7e2f96fe53a1