### PR TITLE
Add project cards and improve header

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -994,6 +994,10 @@
       --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-blue-300) 30%, transparent) var(--tw-shadow-alpha), transparent);
     }
   }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
   .blur-2xl {
     --tw-blur: blur(var(--blur-2xl));
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
@@ -2052,6 +2056,11 @@ section {
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -2202,6 +2211,7 @@ section {
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;

--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const inPagesDir = window.location.pathname.includes("/pages/");
-  const basePath = inPagesDir ? "../" : "./";
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  const depth = segments.length - 1;
+  const basePath = depth === 0 ? "./" : "../".repeat(depth);
 
   // === Load the menu ===
   fetch(`${basePath}components/menu.html`)
@@ -8,19 +9,13 @@ document.addEventListener("DOMContentLoaded", () => {
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;
 
-      if (inPagesDir) {
-        document
-          .querySelectorAll("#menu-container a[href]")
-          .forEach((link) => {
-            const href = link.getAttribute("href");
-            if (!href || href.startsWith("http") || href.startsWith("#")) return;
-            if (href.startsWith("pages/")) {
-              link.setAttribute("href", href.replace("pages/", ""));
-            } else {
-              link.setAttribute("href", `../${href}`);
-            }
-          });
-      }
+      document
+        .querySelectorAll("#menu-container a[href]")
+        .forEach((link) => {
+          const href = link.getAttribute("href");
+          if (!href || href.startsWith("http") || href.startsWith("#")) return;
+          link.setAttribute("href", `${basePath}${href}`);
+        });
 
       initMenu();
     });

--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -1,7 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const segments = window.location.pathname.split("/").filter(Boolean);
-  const depth = segments.length - 1;
-  const basePath = depth === 0 ? "./" : "../".repeat(depth);
+  const script = document.currentScript;
+  let basePath = "./";
+  if (script) {
+    const scriptUrl = new URL(script.getAttribute("src"), window.location.href);
+    basePath = scriptUrl.pathname.replace(/assets\/js\/components\/header\.js$/, "");
+  }
 
   // === Load the menu ===
   fetch(`${basePath}components/menu.html`)

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -1,8 +1,8 @@
 {
-  "HTML": 1854,
-  "CSS": 870,
+  "HTML": 1732,
+  "CSS": 599,
   "SASS": 224,
-  "JavaScript": 431,
+  "JavaScript": 426,
   "PHP": 0,
   "MySQL": 0,
   "React": 0

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -2,7 +2,7 @@
   "HTML": 1732,
   "CSS": 599,
   "SASS": 224,
-  "JavaScript": 426,
+  "JavaScript": 429,
   "PHP": 0,
   "MySQL": 0,
   "React": 0

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -65,78 +65,44 @@
         <h2 class="section-title">Featured Projects</h2>
         <p class="section-subtitle">Check out some of my recent work</p>
         <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <!-- Project Card 1 -->
-          <div class="card card-hoverable card-shadow p-0">
+          <!-- Project Card: 3 Column Preview Card -->
+          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
             <div class="relative h-48">
-              <img src="../assets/images/design_ideas/about.jpg" loading="lazy" width="736" height="552" alt="Crypto Platform" class="h-full w-full object-cover" />
+              <img src="../projects/frontend_mentor/3_column_preview_card/public/images/3%20Column%20preview%20Card%20Image.png" loading="lazy" alt="3 Column Preview Card Screenshot" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">Crypto Platform</h3>
-              <p class="text-gray-600 dark:text-gray-400">A modern cryptocurrency trading platform with real-time price tracking and portfolio management.</p>
+              <h3 class="mb-4 text-xl font-bold">3 Column Preview Card</h3>
+              <p class="text-gray-600 dark:text-gray-400">Responsive 3-column preview card component built for a Frontend Mentor challenge.</p>
               <div class="my-6 flex flex-wrap gap-2">
-                <span class="badge">HTML5</span>
-                <span class="badge">CSS3</span>
-                <span class="badge">JavaScript</span>
-                <span class="badge">API</span>
+                <span data-badge="HTML5"></span>
+                <span data-badge="CSS3"></span>
               </div>
               <div class="flex gap-4">
-                <a href="#" class="btn-sm-primary">YouTube</a>
-                <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
-                <a href="#" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+                <div data-button data-href="../projects/frontend_mentor/3_column_preview_card/public/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
+                <a href="https://github.com/ColinMcArthur85/3-column-preview-card-component" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
                   <i class="fa-brands fa-github mr-2"></i>
                   Code
                 </a>
               </div>
             </div>
           </div>
-          <!-- Project Card 2 -->
-          <div class="card card-hoverable card-shadow p-0">
+
+          <!-- Project Card: Equalizer Landing Page -->
+          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
             <div class="relative h-48">
-              <img src="../assets/images/design_ideas/avatar_all.png" loading="lazy" width="997" height="669" alt="AI Landing Page" class="h-full w-full object-cover" />
+              <img src="../assets/images/design_ideas/avatar_all.png" loading="lazy" alt="Equalizer Landing Page" class="h-full w-full object-cover" />
               <div class="absolute inset-0 bg-black/20"></div>
             </div>
             <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">AI Landing Page</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.</p>
+              <h3 class="mb-4 text-xl font-bold">Equalizer Landing Page</h3>
+              <p class="text-gray-600 dark:text-gray-400">Landing page challenge from Frontend Mentor. Coming soon.</p>
               <div class="my-6 flex flex-wrap gap-2">
-                <span class="badge">HTML5</span>
-                <span class="badge">CSS3</span>
-                <span class="badge">JavaScript</span>
-                <span class="badge">API</span>
+                <span data-badge="HTML5"></span>
+                <span data-badge="CSS3"></span>
               </div>
               <div class="flex gap-4">
-                <a href="#" class="btn-sm-primary">YouTube</a>
-                <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
-                <a href="#" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
-          </div>
-          <!-- Project Card 3 -->
-          <div class="card card-hoverable card-shadow p-0">
-            <div class="relative h-48">
-              <img src="../assets/images/design_ideas/cartridge.png" loading="lazy" width="1972" height="1970" alt="AI Image Detector" class="h-full w-full object-cover" />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">AI Image Detector</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span class="badge">HTML5</span>
-                <span class="badge">CSS3</span>
-                <span class="badge">JavaScript</span>
-                <span class="badge">API</span>
-              </div>
-              <div class="flex gap-4">
-                <a href="#" class="btn-sm-primary">YouTube</a>
-                <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
-                <a href="#" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
+                <div data-button data-href="../projects/frontend_mentor/equalizer_landing_page/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
               </div>
             </div>
           </div>

--- a/public/projects/frontend_mentor/3_column_preview_card/public/index.html
+++ b/public/projects/frontend_mentor/3_column_preview_card/public/index.html
@@ -13,6 +13,16 @@
     />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/normalize.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" />
+    <script>
+      try {
+        const theme = localStorage.getItem("theme");
+        if (theme === "dark" || (!theme && window.matchMedia("(prefers-color-scheme: dark)").matches)) {
+          document.documentElement.classList.add("dark");
+        }
+      } catch (e) {}
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -39,7 +49,8 @@
       }
     </style>
   </head>
-  <body>
+  <body class="dark:bg-dark-background bg-white font-sans text-gray-900 dark:text-white transition-colors duration-300">
+    <div id="menu-container"></div>
     <main>
       <div class="container">
         <div class="card orange">
@@ -88,5 +99,8 @@
         <a href="https://github.com/ColinMcArthur85">Colin McArthur</a>.
       </div>
     </footer>
+    <script src="../../../../assets/js/components/header.js"></script>
+    <script src="../../../../assets/js/expressions.js"></script>
+    <script src="../../../../assets/js/scripts.js"></script>
   </body>
 </html>

--- a/src/js/components/header.js
+++ b/src/js/components/header.js
@@ -1,6 +1,7 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const inPagesDir = window.location.pathname.includes("/pages/");
-  const basePath = inPagesDir ? "../" : "./";
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  const depth = segments.length - 1;
+  const basePath = depth === 0 ? "./" : "../".repeat(depth);
 
   // === Load the menu ===
   fetch(`${basePath}components/menu.html`)
@@ -8,19 +9,13 @@ document.addEventListener("DOMContentLoaded", () => {
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;
 
-      if (inPagesDir) {
-        document
-          .querySelectorAll("#menu-container a[href]")
-          .forEach((link) => {
-            const href = link.getAttribute("href");
-            if (!href || href.startsWith("http") || href.startsWith("#")) return;
-            if (href.startsWith("pages/")) {
-              link.setAttribute("href", href.replace("pages/", ""));
-            } else {
-              link.setAttribute("href", `../${href}`);
-            }
-          });
-      }
+      document
+        .querySelectorAll("#menu-container a[href]")
+        .forEach((link) => {
+          const href = link.getAttribute("href");
+          if (!href || href.startsWith("http") || href.startsWith("#")) return;
+          link.setAttribute("href", `${basePath}${href}`);
+        });
 
       initMenu();
     });

--- a/src/js/components/header.js
+++ b/src/js/components/header.js
@@ -1,7 +1,10 @@
 document.addEventListener("DOMContentLoaded", () => {
-  const segments = window.location.pathname.split("/").filter(Boolean);
-  const depth = segments.length - 1;
-  const basePath = depth === 0 ? "./" : "../".repeat(depth);
+  const script = document.currentScript;
+  let basePath = "./";
+  if (script) {
+    const scriptUrl = new URL(script.getAttribute("src"), window.location.href);
+    basePath = scriptUrl.pathname.replace(/assets\/js\/components\/header\.js$/, "");
+  }
 
   // === Load the menu ===
   fetch(`${basePath}components/menu.html`)


### PR DESCRIPTION
## Summary
- replicate index page project cards on `projects.html`
- support nested paths in header script so menu works in subdirectories
- embed site header in project example `3_column_preview_card`
- rebuild CSS and data

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685895e9ce5883269de804b200f39ff9