### PR TITLE
Fix menu path handling

### DIFF
--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -1,38 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
   // === Load the menu ===
-  fetch("/public/components/menu.html") // Use an absolute path to the menu file
+  const scriptUrl = new URL(document.currentScript.src, window.location.href);
+  const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
+  const menuPath = `${basePath}/components/menu.html`;
+
+  fetch(menuPath)
+    .catch(() => fetch(`/components/menu.html`))
     .then((response) => response.text())
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;
-
-      // Dynamically adjust links based on the current path
-      const pathname = window.location.pathname;
-
-      document.querySelectorAll("#menu-container a[href]").forEach((link) => {
-        const href = link.getAttribute("href");
-        if (!href || href.startsWith("http") || href.startsWith("#")) return;
-
-        if (pathname.includes("/pages/")) {
-          // Adjust links for pages under /pages/
-          if (href.startsWith("pages/")) {
-            link.setAttribute("href", href.replace("pages/", ""));
-          } else {
-            link.setAttribute("href", `../${href}`);
-          }
-        } else if (pathname.includes("/projects/")) {
-          // Adjust links for pages under /projects/
-          const projectsIndex = pathname.indexOf("/projects/");
-          const pathAfterProjects = pathname.substring(projectsIndex + "/projects/".length);
-          const directoryLevels = pathAfterProjects.split("/").filter((segment) => segment !== "").length;
-
-          // Calculate the relative path
-          const basePath = "../".repeat(directoryLevels + 1);
-          link.setAttribute("href", `${basePath}/public/${href}`);
-        }
-      });
-
       initMenu();
-    });
+    })
+    .catch((err) => console.error("Failed to load menu", err));
 
   function initMenu() {
     // === Theme Toggle ===

--- a/public/assets/js/components/header.js
+++ b/public/assets/js/components/header.js
@@ -1,11 +1,15 @@
 document.addEventListener("DOMContentLoaded", () => {
   // === Load the menu ===
-  const scriptUrl = new URL(document.currentScript.src, window.location.href);
-  const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
-  const menuPath = `${basePath}/components/menu.html`;
+  const scriptEl = document.currentScript || document.querySelector('script[src*="header.js"]');
+  let menuPath = "/components/menu.html";
+  if (scriptEl) {
+    const scriptUrl = new URL(scriptEl.src, window.location.href);
+    const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
+    menuPath = `${scriptUrl.origin}${basePath}/components/menu.html`;
+  }
 
   fetch(menuPath)
-    .catch(() => fetch(`/components/menu.html`))
+    .catch(() => fetch("/components/menu.html"))
     .then((response) => response.text())
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;

--- a/public/components/menu.html
+++ b/public/components/menu.html
@@ -1,7 +1,7 @@
 <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
   <div class="container-wrapper">
     <nav class="navbar font-sans">
-      <a href="/index.html">
+      <a href="/public/index.html">
         <div class="flex items-center">
           <span class="text-xl font-extrabold dark:text-white">Colin McArthur</span>
           <span class="ml-1 text-2xl text-primary">●</span>
@@ -9,19 +9,19 @@
       </a>
       <ul class="hidden space-x-8 md:flex">
         <li>
-          <a href="/pages/showcase.html" class="nav-link">Showcase</a>
+          <a href="/public/pages/showcase.html" class="nav-link">Showcase</a>
         </li>
         <li>
-          <a href="/pages/about.html" class="nav-link">About</a>
+          <a href="/public/pages/about.html" class="nav-link">About</a>
         </li>
         <li>
-          <a href="/pages/skills.html" class="nav-link">Skills</a>
+          <a href="/public/pages/skills.html" class="nav-link">Skills</a>
         </li>
         <li>
-          <a href="/pages/projects.html" class="nav-link">Projects</a>
+          <a href="/public/pages/projects.html" class="nav-link">Projects</a>
         </li>
         <li>
-          <a href="/pages/contact.html" class="nav-link">Contact</a>
+          <a href="/public/pages/contact.html" class="nav-link">Contact</a>
         </li>
       </ul>
       <div class="flex items-center space-x-4">
@@ -51,22 +51,22 @@
     </div>
     <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
       <li>
-        <a href="/index.html" class="mobile-nav-link">Home</a>
+        <a href="/public/index.html" class="mobile-nav-link">Home</a>
       </li>
       <li>
-        <a href="/pages/showcase.html" class="mobile-nav-link">Showcase</a>
+        <a href="/public/pages/showcase.html" class="mobile-nav-link">Showcase</a>
       </li>
       <li>
-        <a href="/pages/about.html" class="mobile-nav-link">About</a>
+        <a href="/public/pages/about.html" class="mobile-nav-link">About</a>
       </li>
       <li>
-        <a href="/pages/skills.html" class="mobile-nav-link">Skills</a>
+        <a href="/public/pages/skills.html" class="mobile-nav-link">Skills</a>
       </li>
       <li>
-        <a href="/pages/projects.html" class="mobile-nav-link">Projects</a>
+        <a href="/public/pages/projects.html" class="mobile-nav-link">Projects</a>
       </li>
       <li>
-        <a href="/pages/contact.html" class="mobile-nav-link">Contact</a>
+        <a href="/public/pages/contact.html" class="mobile-nav-link">Contact</a>
       </li>
     </ul>
   </div>

--- a/public/components/menu.html
+++ b/public/components/menu.html
@@ -1,7 +1,7 @@
 <header class="dark:bg-dark-background/95 fixed top-0 z-50 w-full bg-white/95 shadow-sm backdrop-blur-sm transition-all duration-300">
   <div class="container-wrapper">
     <nav class="navbar font-sans">
-      <a href="index.html">
+      <a href="/index.html">
         <div class="flex items-center">
           <span class="text-xl font-extrabold dark:text-white">Colin McArthur</span>
           <span class="ml-1 text-2xl text-primary">●</span>
@@ -9,19 +9,19 @@
       </a>
       <ul class="hidden space-x-8 md:flex">
         <li>
-          <a href="pages/showcase.html" class="nav-link">Showcase</a>
+          <a href="/pages/showcase.html" class="nav-link">Showcase</a>
         </li>
         <li>
-          <a href="pages/about.html" class="nav-link">About</a>
+          <a href="/pages/about.html" class="nav-link">About</a>
         </li>
         <li>
-          <a href="pages/skills.html" class="nav-link">Skills</a>
+          <a href="/pages/skills.html" class="nav-link">Skills</a>
         </li>
         <li>
-          <a href="pages/projects.html" class="nav-link">Projects</a>
+          <a href="/pages/projects.html" class="nav-link">Projects</a>
         </li>
         <li>
-          <a href="pages/contact.html" class="nav-link">Contact</a>
+          <a href="/pages/contact.html" class="nav-link">Contact</a>
         </li>
       </ul>
       <div class="flex items-center space-x-4">
@@ -51,22 +51,22 @@
     </div>
     <ul class="flex flex-1 flex-col items-center justify-center space-y-8">
       <li>
-        <a href="index.html" class="mobile-nav-link">Home</a>
+        <a href="/index.html" class="mobile-nav-link">Home</a>
       </li>
       <li>
-        <a href="pages/showcase.html" class="mobile-nav-link">Showcase</a>
+        <a href="/pages/showcase.html" class="mobile-nav-link">Showcase</a>
       </li>
       <li>
-        <a href="pages/about.html" class="mobile-nav-link">About</a>
+        <a href="/pages/about.html" class="mobile-nav-link">About</a>
       </li>
       <li>
-        <a href="pages/skills.html" class="mobile-nav-link">Skills</a>
+        <a href="/pages/skills.html" class="mobile-nav-link">Skills</a>
       </li>
       <li>
-        <a href="pages/projects.html" class="mobile-nav-link">Projects</a>
+        <a href="/pages/projects.html" class="mobile-nav-link">Projects</a>
       </li>
       <li>
-        <a href="pages/contact.html" class="mobile-nav-link">Contact</a>
+        <a href="/pages/contact.html" class="mobile-nav-link">Contact</a>
       </li>
     </ul>
   </div>

--- a/src/js/components/header.js
+++ b/src/js/components/header.js
@@ -1,38 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
   // === Load the menu ===
-  fetch("/public/components/menu.html") // Use an absolute path to the menu file
+  const scriptUrl = new URL(document.currentScript.src, window.location.href);
+  const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
+  const menuPath = `${basePath}/components/menu.html`;
+
+  fetch(menuPath)
+    .catch(() => fetch(`/components/menu.html`))
     .then((response) => response.text())
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;
-
-      // Dynamically adjust links based on the current path
-      const pathname = window.location.pathname;
-
-      document.querySelectorAll("#menu-container a[href]").forEach((link) => {
-        const href = link.getAttribute("href");
-        if (!href || href.startsWith("http") || href.startsWith("#")) return;
-
-        if (pathname.includes("/pages/")) {
-          // Adjust links for pages under /pages/
-          if (href.startsWith("pages/")) {
-            link.setAttribute("href", href.replace("pages/", ""));
-          } else {
-            link.setAttribute("href", `../${href}`);
-          }
-        } else if (pathname.includes("/projects/")) {
-          // Adjust links for pages under /projects/
-          const projectsIndex = pathname.indexOf("/projects/");
-          const pathAfterProjects = pathname.substring(projectsIndex + "/projects/".length);
-          const directoryLevels = pathAfterProjects.split("/").filter((segment) => segment !== "").length;
-
-          // Calculate the relative path
-          const basePath = "../".repeat(directoryLevels + 1);
-          link.setAttribute("href", `${basePath}/public/${href}`);
-        }
-      });
-
       initMenu();
-    });
+    })
+    .catch((err) => console.error("Failed to load menu", err));
 
   function initMenu() {
     // === Theme Toggle ===

--- a/src/js/components/header.js
+++ b/src/js/components/header.js
@@ -1,11 +1,15 @@
 document.addEventListener("DOMContentLoaded", () => {
   // === Load the menu ===
-  const scriptUrl = new URL(document.currentScript.src, window.location.href);
-  const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
-  const menuPath = `${basePath}/components/menu.html`;
+  const scriptEl = document.currentScript || document.querySelector('script[src*="header.js"]');
+  let menuPath = "/components/menu.html";
+  if (scriptEl) {
+    const scriptUrl = new URL(scriptEl.src, window.location.href);
+    const basePath = scriptUrl.pathname.replace(/\/assets\/js\/components\/header\.js$/, "");
+    menuPath = `${scriptUrl.origin}${basePath}/components/menu.html`;
+  }
 
   fetch(menuPath)
-    .catch(() => fetch(`/components/menu.html`))
+    .catch(() => fetch("/components/menu.html"))
     .then((response) => response.text())
     .then((html) => {
       document.getElementById("menu-container").innerHTML = html;


### PR DESCRIPTION
## Summary
- use absolute links in `menu.html`
- detect base path in `header.js` so it can load `menu.html` regardless of folder structure

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6882df5b632c832680c525f6edaaf999