### PR TITLE
Add dynamic project filtering UI

### DIFF
--- a/public/assets/js/projects.js
+++ b/public/assets/js/projects.js
@@ -1,0 +1,128 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rowsContainer = document.getElementById('project-rows');
+  const techFilterContainer = document.getElementById('filter-tech');
+  const categoryFilterContainer = document.getElementById('filter-category');
+
+  const selectedTech = new Set();
+  const selectedCategories = new Set();
+
+  fetch('../data/projects.json')
+    .then((res) => res.json())
+    .then((projects) => {
+      const categories = [...new Set(projects.map((p) => p.category))];
+      const techs = [...new Set(projects.flatMap((p) => p.tags))];
+
+      renderFilters(categoryFilterContainer, categories, selectedCategories, applyFilters);
+      renderFilters(techFilterContainer, techs, selectedTech, applyFilters);
+
+      renderProjectRows(projects, categories, rowsContainer);
+
+      function applyFilters() {
+        document.querySelectorAll('.category-row').forEach((row) => {
+          const category = row.dataset.category;
+          const container = row.querySelector('.row-scroll');
+          const showRow = selectedCategories.size === 0 || selectedCategories.has(category);
+
+          let visible = 0;
+          container.querySelectorAll('.project-card').forEach((card) => {
+            const tags = card.dataset.tags.split(',');
+            const matchesTech = selectedTech.size === 0 || [...selectedTech].every((t) => tags.includes(t));
+
+            if (showRow && matchesTech) {
+              card.classList.remove('hidden');
+              requestAnimationFrame(() => card.classList.remove('opacity-0'));
+              visible++;
+            } else {
+              card.classList.add('opacity-0');
+              setTimeout(() => card.classList.add('hidden'), 300);
+            }
+          });
+
+          if (showRow && visible > 0) {
+            row.classList.remove('hidden');
+            container.scrollTo({ left: 0, behavior: 'smooth' });
+          } else {
+            row.classList.add('hidden');
+          }
+        });
+      }
+    });
+
+  function renderFilters(container, items, set, onChange) {
+    items.forEach((item) => {
+      const badge = UIComponents.createBadge({ text: item, classes: 'cursor-pointer opacity-60 transition' });
+      badge.addEventListener('click', () => {
+        if (set.has(item)) {
+          set.delete(item);
+          badge.classList.add('opacity-60');
+        } else {
+          set.add(item);
+          badge.classList.remove('opacity-60');
+        }
+        onChange();
+      });
+      container.appendChild(badge);
+    });
+  }
+
+  function renderProjectRows(projects, categories, container) {
+    categories.forEach((cat) => {
+      const section = document.createElement('div');
+      section.className = 'category-row space-y-4';
+      section.dataset.category = cat;
+
+      const heading = document.createElement('h3');
+      heading.className = 'text-xl font-bold';
+      heading.textContent = cat;
+      section.appendChild(heading);
+
+      const row = document.createElement('div');
+      row.className = 'row-scroll flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory';
+      section.appendChild(row);
+
+      projects
+        .filter((p) => p.category === cat)
+        .forEach((project) => {
+          const card = buildProjectCard(project);
+          row.appendChild(card);
+        });
+
+      container.appendChild(section);
+    });
+  }
+
+  function buildProjectCard(project) {
+    const card = document.createElement('div');
+    card.className =
+      'project-card card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary transition-opacity duration-300 flex-shrink-0 w-72 snap-start';
+    card.dataset.tags = project.tags.join(',');
+
+    card.innerHTML = `
+      <div class="relative h-48">
+        <img src="${project.image}" loading="lazy" alt="${project.title}" class="h-full w-full object-cover" />
+        <div class="absolute inset-0 bg-black/20"></div>
+      </div>
+      <div class="p-6">
+        <h3 class="mb-4 text-xl font-bold">${project.title}</h3>
+        <p class="text-gray-600 dark:text-gray-400">${project.description}</p>
+        <div class="badge-container my-6 flex flex-wrap gap-2"></div>
+        <div class="btn-container flex gap-4">
+          <a href="${project.code}" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+            <i class="fa-brands fa-github mr-2"></i>Code
+          </a>
+        </div>
+      </div>`;
+
+    const badgeContainer = card.querySelector('.badge-container');
+    project.tags.forEach((tag) => {
+      const badge = UIComponents.createBadge({ text: tag });
+      badgeContainer.appendChild(badge);
+    });
+
+    const btnContainer = card.querySelector('.btn-container');
+    const viewBtn = UIComponents.createButton({ text: 'View Project', href: project.live, classes: 'btn-sm-primary' });
+    btnContainer.prepend(viewBtn);
+
+    return card;
+  }
+});

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "3-column-preview-card",
+    "title": "3 Column Preview Card",
+    "description": "A mobile responsive 3 column layout",
+    "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "equalizer-landing-page",
+    "title": "Equalizer Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
+    "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
+    "tags": ["HTML5", "CSS3"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "four-card-feature",
+    "title": "Four Card Feature",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit",
+    "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
+    "live": "../projects/frontend_mentor/four_card_feature/index.html",
+    "code": "#",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  }
+]

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -45,97 +45,19 @@
       <div class="container-wrapper">
         <h2 class="section-title">What I've Built</h2>
         <p class="section-subtitle">Finished projects I'm proud to share</p>
-        <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <!-- Project Card 1 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img
-                src="../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg"
-                loading="lazy"
-                width="736"
-                height="552"
-                alt="Crypto Platform"
-                class="h-full w-full object-cover"
-              />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">3 Column Preview Card</h3>
-              <p class="text-gray-600 dark:text-gray-400">A mobile responsive 3 column layout</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-                <span data-badge="SASS"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/3_column_preview_card/public/index.html" data-classes="btn-sm-primary" data-text="View project"></div>
-                <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
-                <a
-                  href="https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card"
-                  class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary"
-                >
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
+
+        <div id="filter-container" class="mb-8 space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Filter by Technology</h3>
+            <div id="filter-tech" class="flex flex-wrap gap-2"></div>
           </div>
-          <!-- Project Card 2 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img src="../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg" loading="lazy" width="997" height="669" alt="AI Landing Page" class="h-full w-full object-cover" />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">Equalizer Landing Page</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/equalizer_landing_page/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
-                <a
-                  href="https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page"
-                  class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary"
-                >
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
-          </div>
-          <!-- Project Card 3 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img
-                src="../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png"
-                loading="lazy"
-                width="1972"
-                height="1970"
-                alt="AI Image Detector"
-                class="h-full w-full object-cover"
-              />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">Four Card Feature</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-                <span data-badge="SASS"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/four_card_feature/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
-                <a href="#" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
+          <div>
+            <h3 class="mb-2 font-semibold">Filter by Category</h3>
+            <div id="filter-category" class="flex flex-wrap gap-2"></div>
           </div>
         </div>
+
+        <div id="project-rows" class="space-y-12"></div>
 
         <h2 class="section-title mt-24">What I'm Learning</h2>
         <p class="section-subtitle">Ongoing lessons, breakthroughs, and debug battles</p>
@@ -233,6 +155,7 @@
     <script src="../assets/js/components/boop.js"></script>
     <script src="../assets/js/components/header.js"></script>
     <script src="../assets/js/components/ui.js"></script>
+    <script src="../assets/js/projects.js"></script>
     <script src="../assets/js/scripts.js"></script>
   </body>
 </html>

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "3-column-preview-card",
+    "title": "3 Column Preview Card",
+    "description": "A mobile responsive 3 column layout",
+    "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "equalizer-landing-page",
+    "title": "Equalizer Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
+    "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
+    "tags": ["HTML5", "CSS3"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "four-card-feature",
+    "title": "Four Card Feature",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit",
+    "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
+    "live": "../projects/frontend_mentor/four_card_feature/index.html",
+    "code": "#",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  }
+]

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -1,0 +1,128 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rowsContainer = document.getElementById('project-rows');
+  const techFilterContainer = document.getElementById('filter-tech');
+  const categoryFilterContainer = document.getElementById('filter-category');
+
+  const selectedTech = new Set();
+  const selectedCategories = new Set();
+
+  fetch('../data/projects.json')
+    .then((res) => res.json())
+    .then((projects) => {
+      const categories = [...new Set(projects.map((p) => p.category))];
+      const techs = [...new Set(projects.flatMap((p) => p.tags))];
+
+      renderFilters(categoryFilterContainer, categories, selectedCategories, applyFilters);
+      renderFilters(techFilterContainer, techs, selectedTech, applyFilters);
+
+      renderProjectRows(projects, categories, rowsContainer);
+
+      function applyFilters() {
+        document.querySelectorAll('.category-row').forEach((row) => {
+          const category = row.dataset.category;
+          const container = row.querySelector('.row-scroll');
+          const showRow = selectedCategories.size === 0 || selectedCategories.has(category);
+
+          let visible = 0;
+          container.querySelectorAll('.project-card').forEach((card) => {
+            const tags = card.dataset.tags.split(',');
+            const matchesTech = selectedTech.size === 0 || [...selectedTech].every((t) => tags.includes(t));
+
+            if (showRow && matchesTech) {
+              card.classList.remove('hidden');
+              requestAnimationFrame(() => card.classList.remove('opacity-0'));
+              visible++;
+            } else {
+              card.classList.add('opacity-0');
+              setTimeout(() => card.classList.add('hidden'), 300);
+            }
+          });
+
+          if (showRow && visible > 0) {
+            row.classList.remove('hidden');
+            container.scrollTo({ left: 0, behavior: 'smooth' });
+          } else {
+            row.classList.add('hidden');
+          }
+        });
+      }
+    });
+
+  function renderFilters(container, items, set, onChange) {
+    items.forEach((item) => {
+      const badge = UIComponents.createBadge({ text: item, classes: 'cursor-pointer opacity-60 transition' });
+      badge.addEventListener('click', () => {
+        if (set.has(item)) {
+          set.delete(item);
+          badge.classList.add('opacity-60');
+        } else {
+          set.add(item);
+          badge.classList.remove('opacity-60');
+        }
+        onChange();
+      });
+      container.appendChild(badge);
+    });
+  }
+
+  function renderProjectRows(projects, categories, container) {
+    categories.forEach((cat) => {
+      const section = document.createElement('div');
+      section.className = 'category-row space-y-4';
+      section.dataset.category = cat;
+
+      const heading = document.createElement('h3');
+      heading.className = 'text-xl font-bold';
+      heading.textContent = cat;
+      section.appendChild(heading);
+
+      const row = document.createElement('div');
+      row.className = 'row-scroll flex gap-6 overflow-x-auto pb-4 snap-x snap-mandatory';
+      section.appendChild(row);
+
+      projects
+        .filter((p) => p.category === cat)
+        .forEach((project) => {
+          const card = buildProjectCard(project);
+          row.appendChild(card);
+        });
+
+      container.appendChild(section);
+    });
+  }
+
+  function buildProjectCard(project) {
+    const card = document.createElement('div');
+    card.className =
+      'project-card card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary transition-opacity duration-300 flex-shrink-0 w-72 snap-start';
+    card.dataset.tags = project.tags.join(',');
+
+    card.innerHTML = `
+      <div class="relative h-48">
+        <img src="${project.image}" loading="lazy" alt="${project.title}" class="h-full w-full object-cover" />
+        <div class="absolute inset-0 bg-black/20"></div>
+      </div>
+      <div class="p-6">
+        <h3 class="mb-4 text-xl font-bold">${project.title}</h3>
+        <p class="text-gray-600 dark:text-gray-400">${project.description}</p>
+        <div class="badge-container my-6 flex flex-wrap gap-2"></div>
+        <div class="btn-container flex gap-4">
+          <a href="${project.code}" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+            <i class="fa-brands fa-github mr-2"></i>Code
+          </a>
+        </div>
+      </div>`;
+
+    const badgeContainer = card.querySelector('.badge-container');
+    project.tags.forEach((tag) => {
+      const badge = UIComponents.createBadge({ text: tag });
+      badgeContainer.appendChild(badge);
+    });
+
+    const btnContainer = card.querySelector('.btn-container');
+    const viewBtn = UIComponents.createButton({ text: 'View Project', href: project.live, classes: 'btn-sm-primary' });
+    btnContainer.prepend(viewBtn);
+
+    return card;
+  }
+});


### PR DESCRIPTION
## Summary
- store project metadata in `projects.json` for easier scaling
- add `projects.js` to render Netflix-style horizontal project rows with badge filters
- wire up filters on `projects.html` and load the new script

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68903af40d1483269a509b540040cd72