### PR TITLE
Add dynamic project filtering UI

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -296,9 +296,6 @@
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
   }
-  .my-6 {
-    margin-block: calc(var(--spacing) * 6);
-  }
   .mt-1 {
     margin-top: calc(var(--spacing) * 1);
   }
@@ -310,6 +307,9 @@
   }
   .mt-24 {
     margin-top: calc(var(--spacing) * 24);
+  }
+  .mt-auto {
+    margin-top: auto;
   }
   .mr-2 {
     margin-right: calc(var(--spacing) * 2);
@@ -444,6 +444,12 @@
   .animate-morph {
     animation: var(--animate-morph);
   }
+  .cursor-not-allowed {
+    cursor: not-allowed;
+  }
+  .cursor-pointer {
+    cursor: pointer;
+  }
   .list-disc {
     list-style-type: disc;
   }
@@ -546,6 +552,12 @@
   }
   .border-gray-900 {
     border-color: var(--color-gray-900);
+  }
+  .border-primary {
+    border-color: var(--color-primary);
+  }
+  .border-transparent {
+    border-color: transparent;
   }
   .bg-\[var\(--color-css3\)\]\/15 {
     background-color: color-mix(in srgb, #2965f1 15%, transparent);
@@ -819,6 +831,9 @@
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
   }
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
   .px-8 {
     padding-inline: calc(var(--spacing) * 8);
   }
@@ -906,6 +921,10 @@
     --tw-font-weight: var(--font-weight-medium);
     font-weight: var(--font-weight-medium);
   }
+  .font-semibold {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+  }
   .text-\[var\(--color-css3\)\] {
     color: var(--color-css3);
   }
@@ -968,6 +987,12 @@
   }
   .opacity-0 {
     opacity: 0%;
+  }
+  .opacity-50 {
+    opacity: 50%;
+  }
+  .opacity-60 {
+    opacity: 60%;
   }
   .opacity-100 {
     opacity: 100%;

--- a/public/assets/js/projects.js
+++ b/public/assets/js/projects.js
@@ -1,0 +1,186 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const listContainer = document.getElementById("project-list");
+  const paginationContainer = document.getElementById("pagination");
+  const techFilterContainer = document.getElementById("filter-tech");
+  const categoryFilterContainer = document.getElementById("filter-category");
+
+  const storageKey = "projectFilters";
+  let stored = {};
+  try {
+    stored = JSON.parse(localStorage.getItem(storageKey)) || {};
+  } catch (e) {
+    stored = {};
+  }
+
+  const selectedTech = new Set(stored.tech || []);
+  const selectedCategories = new Set(stored.categories || []);
+
+  function saveFilters() {
+    try {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          tech: [...selectedTech],
+          categories: [...selectedCategories],
+        }),
+      );
+    } catch (e) {}
+  }
+
+  fetch("../data/projects.json")
+    .then((res) => res.json())
+    .then((projects) => {
+      const categories = [...new Set(projects.map((p) => p.category))];
+      const techs = [...new Set(projects.flatMap((p) => p.tags))];
+
+      renderFilters(
+        categoryFilterContainer,
+        categories,
+        selectedCategories,
+        applyFilters,
+      );
+      renderFilters(techFilterContainer, techs, selectedTech, applyFilters);
+
+      let filtered = [];
+      let currentPage = 1;
+      const perPage = 6;
+
+      function applyFilters() {
+        if (selectedCategories.size === 0 && selectedTech.size === 0) {
+          filtered = [];
+        } else {
+          filtered = projects.filter((p) => (selectedCategories.size === 0 || selectedCategories.has(p.category)) && (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))));
+        }
+        currentPage = 1;
+        renderPage();
+      }
+
+      function renderPage() {
+        const oldCards = [...listContainer.children];
+        if (oldCards.length) {
+          oldCards.forEach((card) => card.classList.add("opacity-0", "translate-y-4"));
+        }
+
+        setTimeout(
+          () => {
+            listContainer.innerHTML = "";
+            const start = (currentPage - 1) * perPage;
+            const pageProjects = filtered.slice(start, start + perPage);
+            if (pageProjects.length === 0) {
+              const msg = document.createElement("p");
+              msg.textContent = selectedCategories.size === 0 && selectedTech.size === 0 ? "Please make a selection" : "No projects match your filters";
+              msg.className = "text-center text-gray-600 dark:text-gray-400";
+              listContainer.appendChild(msg);
+            } else {
+              pageProjects.forEach((project) => {
+                const card = buildProjectCard(project);
+                listContainer.appendChild(card);
+                requestAnimationFrame(() => {
+                  card.classList.remove("opacity-0", "translate-y-4");
+                });
+              });
+              renderPagination();
+            }
+          },
+          oldCards.length ? 300 : 0,
+        );
+      }
+
+      function renderPagination() {
+        paginationContainer.innerHTML = "";
+        const totalPages = Math.ceil(filtered.length / perPage);
+        if (totalPages <= 1) return;
+
+        const prev = UIComponents.createButton({ text: "Prev", classes: "btn-secondary" });
+        prev.disabled = currentPage === 1;
+        if (prev.disabled) prev.classList.add("opacity-50", "cursor-not-allowed");
+        prev.addEventListener("click", () => {
+          if (currentPage > 1) {
+            currentPage--;
+            renderPage();
+          }
+        });
+
+        const next = UIComponents.createButton({ text: "Next", classes: "btn-secondary" });
+        next.disabled = currentPage === totalPages;
+        if (next.disabled) next.classList.add("opacity-50", "cursor-not-allowed");
+        next.addEventListener("click", () => {
+          if (currentPage < totalPages) {
+            currentPage++;
+            renderPage();
+          }
+        });
+
+        const info = document.createElement("span");
+        info.textContent = `Page ${currentPage} of ${totalPages}`;
+        info.className = "px-4";
+
+        paginationContainer.append(prev, info, next);
+      }
+
+      applyFilters();
+    });
+
+  function renderFilters(container, items, set, onChange) {
+    items.forEach((item) => {
+      const isActive = set.has(item);
+      const badge = UIComponents.createBadge({
+        text: item,
+        classes: `cursor-pointer transition border ${
+          isActive ? "border-primary" : "border-transparent opacity-60"
+        }`,
+      });
+      badge.setAttribute("aria-pressed", isActive ? "true" : "false");
+      badge.addEventListener("click", () => {
+        if (set.has(item)) {
+          set.delete(item);
+          badge.classList.add("opacity-60");
+          badge.classList.remove("border-primary");
+          badge.setAttribute("aria-pressed", "false");
+        } else {
+          set.add(item);
+          badge.classList.remove("opacity-60");
+          badge.classList.add("border-primary");
+          badge.setAttribute("aria-pressed", "true");
+        }
+        saveFilters();
+        onChange();
+      });
+      container.appendChild(badge);
+    });
+  }
+
+  function buildProjectCard(project) {
+    const card = document.createElement("div");
+    card.className = "project-card card card-hoverable card-shadow p-0 flex flex-col h-full dark:bg-dark-background-secondary transition duration-300 opacity-0 translate-y-4";
+    card.dataset.tags = project.tags.join(",");
+
+    card.innerHTML = `
+      <div class="relative h-48">
+        <img src="${project.image}" loading="lazy" alt="${project.title}" class="h-full w-full object-cover" />
+        <div class="absolute inset-0 bg-black/20"></div>
+      </div>
+      <div class="flex flex-1 flex-col p-6">
+        <h3 class="mb-4 text-xl font-bold">${project.title}</h3>
+        <p class="mb-4 text-gray-600 dark:text-gray-400">${project.description}</p>
+        <div class="badge-container mb-6 mt-auto flex flex-wrap gap-2"></div>
+        <div class="btn-container flex gap-4">
+          <a href="${project.code}" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+            <i class="fa-brands fa-github mr-2"></i>Code
+          </a>
+        </div>
+      </div>`;
+
+    const badgeContainer = card.querySelector(".badge-container");
+    project.tags.forEach((tag) => {
+      const badge = UIComponents.createBadge({ text: tag });
+      badgeContainer.appendChild(badge);
+    });
+
+    const btnContainer = card.querySelector(".btn-container");
+    const viewBtn = UIComponents.createButton({ text: "View Project", href: project.live, classes: "btn-sm-primary" });
+    btnContainer.prepend(viewBtn);
+
+    return card;
+  }
+});

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "3-column-preview-card",
+    "title": "3 Column Preview Card",
+    "description": "A mobile responsive 3 column layout",
+    "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "equalizer-landing-page",
+    "title": "Equalizer Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
+    "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
+    "tags": ["HTML5", "CSS3"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "four-card-feature",
+    "title": "Four Card Feature",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit",
+    "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
+    "live": "../projects/frontend_mentor/four_card_feature/index.html",
+    "code": "#",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  }
+]

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -45,97 +45,20 @@
       <div class="container-wrapper">
         <h2 class="section-title">What I've Built</h2>
         <p class="section-subtitle">Finished projects I'm proud to share</p>
-        <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <!-- Project Card 1 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img
-                src="../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg"
-                loading="lazy"
-                width="736"
-                height="552"
-                alt="Crypto Platform"
-                class="h-full w-full object-cover"
-              />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">3 Column Preview Card</h3>
-              <p class="text-gray-600 dark:text-gray-400">A mobile responsive 3 column layout</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-                <span data-badge="SASS"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/3_column_preview_card/public/index.html" data-classes="btn-sm-primary" data-text="View project"></div>
-                <!-- For my portfolio, 👆 this will link to a 'live preview' of the page -->
-                <a
-                  href="https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card"
-                  class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary"
-                >
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
+
+        <div id="filter-container" class="mb-8 space-y-4">
+          <div>
+            <h3 class="mb-2 font-semibold">Filter by Technology</h3>
+            <div id="filter-tech" class="flex flex-wrap gap-2"></div>
           </div>
-          <!-- Project Card 2 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img src="../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg" loading="lazy" width="997" height="669" alt="AI Landing Page" class="h-full w-full object-cover" />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">Equalizer Landing Page</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/equalizer_landing_page/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
-                <a
-                  href="https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page"
-                  class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary"
-                >
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
-          </div>
-          <!-- Project Card 3 -->
-          <div class="card card-hoverable card-shadow p-0 dark:bg-dark-background-secondary">
-            <div class="relative h-48">
-              <img
-                src="../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png"
-                loading="lazy"
-                width="1972"
-                height="1970"
-                alt="AI Image Detector"
-                class="h-full w-full object-cover"
-              />
-              <div class="absolute inset-0 bg-black/20"></div>
-            </div>
-            <div class="p-6">
-              <h3 class="mb-4 text-xl font-bold">Four Card Feature</h3>
-              <p class="text-gray-600 dark:text-gray-400">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit</p>
-              <div class="my-6 flex flex-wrap gap-2">
-                <span data-badge="HTML5"></span>
-                <span data-badge="CSS3"></span>
-                <span data-badge="SASS"></span>
-              </div>
-              <div class="flex gap-4">
-                <div data-button data-href="../projects/frontend_mentor/four_card_feature/index.html" data-classes="btn-sm-primary" data-text="View Project"></div>
-                <a href="#" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
-                  <i class="fa-brands fa-github mr-2"></i>
-                  Code
-                </a>
-              </div>
-            </div>
+          <div>
+            <h3 class="mb-2 font-semibold">Filter by Category</h3>
+            <div id="filter-category" class="flex flex-wrap gap-2"></div>
           </div>
         </div>
+
+        <div id="project-list" class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3"></div>
+        <div id="pagination" class="mt-8 flex items-center justify-center gap-4"></div>
 
         <h2 class="section-title mt-24">What I'm Learning</h2>
         <p class="section-subtitle">Ongoing lessons, breakthroughs, and debug battles</p>
@@ -233,6 +156,7 @@
     <script src="../assets/js/components/boop.js"></script>
     <script src="../assets/js/components/header.js"></script>
     <script src="../assets/js/components/ui.js"></script>
+    <script src="../assets/js/projects.js"></script>
     <script src="../assets/js/scripts.js"></script>
   </body>
 </html>

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "3-column-preview-card",
+    "title": "3 Column Preview Card",
+    "description": "A mobile responsive 3 column layout",
+    "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "equalizer-landing-page",
+    "title": "Equalizer Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
+    "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
+    "tags": ["HTML5", "CSS3"],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "four-card-feature",
+    "title": "Four Card Feature",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit",
+    "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
+    "live": "../projects/frontend_mentor/four_card_feature/index.html",
+    "code": "#",
+    "tags": ["HTML5", "CSS3", "SASS"],
+    "category": "Frontend Mentor"
+  }
+]

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -1,0 +1,186 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const listContainer = document.getElementById("project-list");
+  const paginationContainer = document.getElementById("pagination");
+  const techFilterContainer = document.getElementById("filter-tech");
+  const categoryFilterContainer = document.getElementById("filter-category");
+
+  const storageKey = "projectFilters";
+  let stored = {};
+  try {
+    stored = JSON.parse(localStorage.getItem(storageKey)) || {};
+  } catch (e) {
+    stored = {};
+  }
+
+  const selectedTech = new Set(stored.tech || []);
+  const selectedCategories = new Set(stored.categories || []);
+
+  function saveFilters() {
+    try {
+      localStorage.setItem(
+        storageKey,
+        JSON.stringify({
+          tech: [...selectedTech],
+          categories: [...selectedCategories],
+        }),
+      );
+    } catch (e) {}
+  }
+
+  fetch("../data/projects.json")
+    .then((res) => res.json())
+    .then((projects) => {
+      const categories = [...new Set(projects.map((p) => p.category))];
+      const techs = [...new Set(projects.flatMap((p) => p.tags))];
+
+      renderFilters(
+        categoryFilterContainer,
+        categories,
+        selectedCategories,
+        applyFilters,
+      );
+      renderFilters(techFilterContainer, techs, selectedTech, applyFilters);
+
+      let filtered = [];
+      let currentPage = 1;
+      const perPage = 6;
+
+      function applyFilters() {
+        if (selectedCategories.size === 0 && selectedTech.size === 0) {
+          filtered = [];
+        } else {
+          filtered = projects.filter((p) => (selectedCategories.size === 0 || selectedCategories.has(p.category)) && (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))));
+        }
+        currentPage = 1;
+        renderPage();
+      }
+
+      function renderPage() {
+        const oldCards = [...listContainer.children];
+        if (oldCards.length) {
+          oldCards.forEach((card) => card.classList.add("opacity-0", "translate-y-4"));
+        }
+
+        setTimeout(
+          () => {
+            listContainer.innerHTML = "";
+            const start = (currentPage - 1) * perPage;
+            const pageProjects = filtered.slice(start, start + perPage);
+            if (pageProjects.length === 0) {
+              const msg = document.createElement("p");
+              msg.textContent = selectedCategories.size === 0 && selectedTech.size === 0 ? "Please make a selection" : "No projects match your filters";
+              msg.className = "text-center text-gray-600 dark:text-gray-400";
+              listContainer.appendChild(msg);
+            } else {
+              pageProjects.forEach((project) => {
+                const card = buildProjectCard(project);
+                listContainer.appendChild(card);
+                requestAnimationFrame(() => {
+                  card.classList.remove("opacity-0", "translate-y-4");
+                });
+              });
+              renderPagination();
+            }
+          },
+          oldCards.length ? 300 : 0,
+        );
+      }
+
+      function renderPagination() {
+        paginationContainer.innerHTML = "";
+        const totalPages = Math.ceil(filtered.length / perPage);
+        if (totalPages <= 1) return;
+
+        const prev = UIComponents.createButton({ text: "Prev", classes: "btn-secondary" });
+        prev.disabled = currentPage === 1;
+        if (prev.disabled) prev.classList.add("opacity-50", "cursor-not-allowed");
+        prev.addEventListener("click", () => {
+          if (currentPage > 1) {
+            currentPage--;
+            renderPage();
+          }
+        });
+
+        const next = UIComponents.createButton({ text: "Next", classes: "btn-secondary" });
+        next.disabled = currentPage === totalPages;
+        if (next.disabled) next.classList.add("opacity-50", "cursor-not-allowed");
+        next.addEventListener("click", () => {
+          if (currentPage < totalPages) {
+            currentPage++;
+            renderPage();
+          }
+        });
+
+        const info = document.createElement("span");
+        info.textContent = `Page ${currentPage} of ${totalPages}`;
+        info.className = "px-4";
+
+        paginationContainer.append(prev, info, next);
+      }
+
+      applyFilters();
+    });
+
+  function renderFilters(container, items, set, onChange) {
+    items.forEach((item) => {
+      const isActive = set.has(item);
+      const badge = UIComponents.createBadge({
+        text: item,
+        classes: `cursor-pointer transition border ${
+          isActive ? "border-primary" : "border-transparent opacity-60"
+        }`,
+      });
+      badge.setAttribute("aria-pressed", isActive ? "true" : "false");
+      badge.addEventListener("click", () => {
+        if (set.has(item)) {
+          set.delete(item);
+          badge.classList.add("opacity-60");
+          badge.classList.remove("border-primary");
+          badge.setAttribute("aria-pressed", "false");
+        } else {
+          set.add(item);
+          badge.classList.remove("opacity-60");
+          badge.classList.add("border-primary");
+          badge.setAttribute("aria-pressed", "true");
+        }
+        saveFilters();
+        onChange();
+      });
+      container.appendChild(badge);
+    });
+  }
+
+  function buildProjectCard(project) {
+    const card = document.createElement("div");
+    card.className = "project-card card card-hoverable card-shadow p-0 flex flex-col h-full dark:bg-dark-background-secondary transition duration-300 opacity-0 translate-y-4";
+    card.dataset.tags = project.tags.join(",");
+
+    card.innerHTML = `
+      <div class="relative h-48">
+        <img src="${project.image}" loading="lazy" alt="${project.title}" class="h-full w-full object-cover" />
+        <div class="absolute inset-0 bg-black/20"></div>
+      </div>
+      <div class="flex flex-1 flex-col p-6">
+        <h3 class="mb-4 text-xl font-bold">${project.title}</h3>
+        <p class="mb-4 text-gray-600 dark:text-gray-400">${project.description}</p>
+        <div class="badge-container mb-6 mt-auto flex flex-wrap gap-2"></div>
+        <div class="btn-container flex gap-4">
+          <a href="${project.code}" class="flex items-center text-gray-600 transition-colors hover:text-primary dark:text-gray-400 dark:hover:text-primary">
+            <i class="fa-brands fa-github mr-2"></i>Code
+          </a>
+        </div>
+      </div>`;
+
+    const badgeContainer = card.querySelector(".badge-container");
+    project.tags.forEach((tag) => {
+      const badge = UIComponents.createBadge({ text: tag });
+      badgeContainer.appendChild(badge);
+    });
+
+    const btnContainer = card.querySelector(".btn-container");
+    const viewBtn = UIComponents.createButton({ text: "View Project", href: project.live, classes: "btn-sm-primary" });
+    btnContainer.prepend(viewBtn);
+
+    return card;
+  }
+});


### PR DESCRIPTION
## Summary
- store project metadata in `projects.json` for easier scaling
- add `projects.js` to render a filterable project grid with badge highlights and pagination
- wire up filters on `projects.html` and load the new script
- highlight active badges with a primary border for clearer filter state
- hide projects by default and prompt users to pick a filter
- use union matching for tech filters so multiple tags show all applicable projects
- animate project cards in and out for smoother filtering transitions
- remember last-used filters in localStorage so returning visitors see prior selections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68903af40d1483269a509b540040cd72