### PR TITLE
feat: add frontend mentor projects

### DIFF
--- a/public/assets/js/projects.js
+++ b/public/assets/js/projects.js
@@ -3,6 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const paginationContainer = document.getElementById("pagination");
   const techFilterContainer = document.getElementById("filter-tech");
   const categoryFilterContainer = document.getElementById("filter-category");
+  const resultsCount = document.getElementById("results-count");
 
   const storageKey = "projectFilters";
   let stored = {};
@@ -48,8 +49,15 @@ document.addEventListener("DOMContentLoaded", () => {
       function applyFilters() {
         if (selectedCategories.size === 0 && selectedTech.size === 0) {
           filtered = [];
+          if (resultsCount) resultsCount.textContent = "";
         } else {
-          filtered = projects.filter((p) => (selectedCategories.size === 0 || selectedCategories.has(p.category)) && (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))));
+          filtered = projects.filter(
+            (p) =>
+              (selectedCategories.size === 0 || selectedCategories.has(p.category)) &&
+              (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))),
+          );
+          if (resultsCount)
+            resultsCount.textContent = `${filtered.length} project${filtered.length === 1 ? "" : "s"} found`;
         }
         currentPage = 1;
         renderPage();

--- a/public/data/projects.json
+++ b/public/data/projects.json
@@ -6,7 +6,11 @@
     "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
     "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
     "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
-    "tags": ["HTML5", "CSS3", "SASS"],
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
     "category": "Frontend Mentor"
   },
   {
@@ -16,7 +20,10 @@
     "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
     "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
     "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
-    "tags": ["HTML5", "CSS3"],
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
     "category": "Frontend Mentor"
   },
   {
@@ -26,7 +33,175 @@
     "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
     "live": "../projects/frontend_mentor/four_card_feature/index.html",
     "code": "#",
-    "tags": ["HTML5", "CSS3", "SASS"],
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "huddle-landing-page",
+    "title": "Huddle Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/huddle_landing_page/docs/images/Huddle%20Landing%20Page.png",
+    "live": "../projects/frontend_mentor/huddle_landing_page/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/huddle_landing_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "meeting-landing-page",
+    "title": "Meeting Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/meeting_landing_page/public/assets/Meet%20Landing%20Page%20Final.png",
+    "live": "../projects/frontend_mentor/meeting_landing_page/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/meeting_landing_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "nft-card",
+    "title": "NFT Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/nft_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/nft_card/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/nft_card",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "notifications-page",
+    "title": "Notifications Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/notifications_page/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/notifications_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/notifications_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "order-summary-component",
+    "title": "Order Summary Component",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/order_summary_component/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/order_summary_component/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/order_summary_component",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "pricingblock",
+    "title": "Pricing Block",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "https://via.placeholder.com/300x200?text=Pricing%20Block",
+    "live": "../projects/frontend_mentor/pricingblock/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/pricingblock",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "product-preview-card",
+    "title": "Product Preview Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/product_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/product_preview_card/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/product_preview_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "profile-card",
+    "title": "Profile Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/profile_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/profile_card/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/profile_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "qr-code",
+    "title": "QR Code",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/qr_code/Desktop.png",
+    "live": "../projects/frontend_mentor/qr_code/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/qr_code",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "results-summary",
+    "title": "Results Summary",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/results_summary/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/results_summary/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/results_summary",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "social-proof",
+    "title": "Social Proof",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/social_proof/src/assets/Layouts/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/social_proof/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/social_proof",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "stats-card",
+    "title": "Stats Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/stats_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/stats_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/stats_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
     "category": "Frontend Mentor"
   }
 ]

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -56,6 +56,7 @@
             <div id="filter-category" class="flex flex-wrap gap-2"></div>
           </div>
         </div>
+        <p id="results-count" class="mb-4 text-sm text-gray-600 dark:text-gray-400"></p>
 
         <div id="project-list" class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3"></div>
         <div id="pagination" class="mt-8 flex items-center justify-center gap-4"></div>

--- a/public/projects/frontend_mentor/huddle_landing_page/docs/index.html
+++ b/public/projects/frontend_mentor/huddle_landing_page/docs/index.html
@@ -7,6 +7,7 @@
 
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="styles.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/projects/frontend_mentor/huddle_landing_page/docs/index.html
+++ b/public/projects/frontend_mentor/huddle_landing_page/docs/index.html
@@ -1,33 +1,20 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="styles.css" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap"
-      rel="stylesheet"
-    />
-    <title>
-      Frontend Mentor | Huddle landing page with single introductory section
-    </title>
+    <link href="https://fonts.googleapis.com/css2?family=Open+Sans&display=swap" rel="stylesheet" />
+    <title>Frontend Mentor | Huddle landing page with single introductory section</title>
 
     <!-- Feel free to remove these styles or customise in your own stylesheet 👍 -->
     <style>
@@ -41,6 +28,7 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <section class="flex-col">
         <div class="logo">
@@ -50,22 +38,15 @@
           <div class="bg-image col-split">
             <div class="flex-col">
               <div class="hero">
-                <img
-                  src="/docs/images/illustration-mockups.svg"
-                  alt="Illustration"
-                />
+                <img src="/docs/images/illustration-mockups.svg" alt="Illustration" />
               </div>
             </div>
           </div>
           <div class="col-split">
             <div class="hero-content">
-              <h1 class="hero-content__title">
-                Build The Community Your Fans Will Love
-              </h1>
+              <h1 class="hero-content__title">Build The Community Your Fans Will Love</h1>
               <p class="hero-content__body">
-                Huddle re-imagines the way we build communities. You have a
-                voice, but so does your audience. Create connections with your
-                users as you engage in genuine discussion.
+                Huddle re-imagines the way we build communities. You have a voice, but so does your audience. Create connections with your users as you engage in genuine discussion.
               </p>
             </div>
             <div class="flex-col">
@@ -75,7 +56,8 @@
         </div>
         <div class="hero-icons flex-row">
           <div class="hero-icons__fb">
-            <?xml version="1.0" ?><!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
+            <?xml version="1.0" ?>
+            <!DOCTYPE svg PUBLIC '-//W3C//DTD SVG 1.1//EN' 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'>
             <svg
               enable-background="new 0 0 100 100"
               height="30px"
@@ -153,10 +135,12 @@
     <footer>
       <p class="attribution">
         Challenge by
-        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-          >Frontend Mentor</a
-        >. Coded by <a href="#">Colin McArthur</a>.
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Colin McArthur</a>
+        .
       </p>
     </footer>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/meeting_landing_page/public/index.html
+++ b/public/projects/frontend_mentor/meeting_landing_page/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -13,6 +13,7 @@
     <title>Meet landing page</title>
   </head>
   <body>
+    <div id="menu-container"></div>
     <div class="container">
       <header>
         <figure class="hero">
@@ -66,7 +67,9 @@
               <div class="flow">
                 <div class="about-overline">Built for modern use</div>
                 <h2 class="about-title">Smarter meetings, all in one place</h2>
-                <p class="about-body">Send messages, share files, show your screen, and record your meetings — all in one workspace. Control who can join with invite-only team access, data encryption, and data export.</p>
+                <p class="about-body">
+                  Send messages, share files, show your screen, and record your meetings — all in one workspace. Control who can join with invite-only team access, data encryption, and data export.
+                </p>
                 <div class="line"></div>
                 <div class="circle flex-center" data-type="bottom">02</div>
               </div>
@@ -89,5 +92,6 @@
         </section>
       </footer>
     </div>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/meeting_landing_page/public/index.html
+++ b/public/projects/frontend_mentor/meeting_landing_page/public/index.html
@@ -6,6 +6,7 @@
 
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon-32x32.png" />
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;600;700&display=swap" rel="stylesheet" />

--- a/public/projects/frontend_mentor/nft_card/index.html
+++ b/public/projects/frontend_mentor/nft_card/index.html
@@ -6,6 +6,7 @@
     <!-- displays site properly based on user's device -->
     <link rel="stylesheet" href="./css/general-styling.css" />
     <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
 
     <title>Frontend Mentor | NFT preview card component</title>

--- a/public/projects/frontend_mentor/nft_card/index.html
+++ b/public/projects/frontend_mentor/nft_card/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,29 +6,23 @@
     <!-- displays site properly based on user's device -->
     <link rel="stylesheet" href="./css/general-styling.css" />
     <link rel="stylesheet" href="./css/style.css" />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
 
     <title>Frontend Mentor | NFT preview card component</title>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <div class="container">
         <div class="card">
           <div class="card__image">
-            <a href="#"><img src="./images/image-equilibrium.jpg" alt="" /> </a>
+            <a href="#"><img src="./images/image-equilibrium.jpg" alt="" /></a>
           </div>
           <div class="card__content">
             <h1 class="card__content__title">
               <a href="">Equilibrium #3429</a>
             </h1>
-            <p class="card__content__body">
-              Our Equilibrium collection promotes balance and calm.
-            </p>
+            <p class="card__content__body">Our Equilibrium collection promotes balance and calm.</p>
             <div class="card__eth__time">
               <div class="card__eth">
                 <img src="./images/icon-ethereum.svg" alt="" />
@@ -44,19 +38,20 @@
           <div class="card__creator">
             <img src="./images/image-avatar.png" alt="" />
             <p>
-              Creation of<span> <a href="#">Jules Wyvern</a></span>
+              Creation of
+              <span><a href="#">Jules Wyvern</a></span>
             </p>
           </div>
           <div class="attribution">
             Challenge by
-            <a
-              href="https://www.frontendmentor.io?ref=challenge"
-              target="_blank"
-              >Frontend Mentor</a
-            >. Coded by <a href="#">Colin McArthur</a>.
+            <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+            . Coded by
+            <a href="#">Colin McArthur</a>
+            .
           </div>
         </div>
       </div>
     </main>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/notifications_page/index.html
+++ b/public/projects/frontend_mentor/notifications_page/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
     <link rel="stylesheet" href="docs/styles.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/images/favicon-32x32.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/projects/frontend_mentor/notifications_page/index.html
+++ b/public/projects/frontend_mentor/notifications_page/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -13,6 +13,7 @@
     <title>Frontend Mentor | Notifications page</title>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <section class="notification-panel">
         <div class="container">
@@ -28,28 +29,45 @@
             <li class="notification-item active" data-name="Mark Webber">
               <img class="notification-profile" src="assets/images/avatar-mark-webber.webp" width="50px" height="50px" alt="Mark Webber's profile picture" />
               <div class="notification-content">
-                <p class="notification-title"><a>Mark Webber</a> reacted to your recent post <a>My first tournament today!</a><span class="unread-indicator"></span></p>
+                <p class="notification-title">
+                  <a>Mark Webber</a>
+                  reacted to your recent post
+                  <a>My first tournament today!</a>
+                  <span class="unread-indicator"></span>
+                </p>
                 <p class="notification-description">1m ago</p>
               </div>
             </li>
             <li class="notification-item active" data-name="Angela Gray">
               <img class="notification-profile" src="assets/images/avatar-angela-gray.webp" width="50px" height="50px" alt="Angela Gray's profile picture" />
               <div class="notification-content">
-                <p class="notification-title"><a>Angela Gray</a> followed you<span class="unread-indicator"></span></p>
+                <p class="notification-title">
+                  <a>Angela Gray</a>
+                  followed you
+                  <span class="unread-indicator"></span>
+                </p>
                 <p class="notification-description">5m ago</p>
               </div>
             </li>
             <li class="notification-item active" data-name="Jacob Thompson">
               <img class="notification-profile" src="assets/images/avatar-jacob-thompson.webp" width="50px" height="50px" alt="Jacob Thompson's profile picture" />
               <div class="notification-content">
-                <p class="notification-title"><a>Jacob Thompson</a> has joined your group <a class="group-link">Chess Club</a><span class="unread-indicator"></span></p>
+                <p class="notification-title">
+                  <a>Jacob Thompson</a>
+                  has joined your group
+                  <a class="group-link">Chess Club</a>
+                  <span class="unread-indicator"></span>
+                </p>
                 <p class="notification-description">1 day ago</p>
               </div>
             </li>
             <li class="notification-item" data-name="Rizky Hasanuddin">
               <img class="notification-profile" src="assets/images/avatar-rizky-hasanuddin.webp" width="50px" height="50px" alt="Rizky Hasanuddin's profile picture" />
               <div class="notification-content">
-                <p class="notification-title"><a>Rizky Hasanuddin</a> sent you a private message</p>
+                <p class="notification-title">
+                  <a>Rizky Hasanuddin</a>
+                  sent you a private message
+                </p>
                 <p class="notification-description">5 days ago</p>
                 <div class="notification-comment">Hello, thanks for setting up the Chess Club. I've been a member for a few weeks now and I'm already having lots of fun and improving my game.</div>
               </div>
@@ -57,7 +75,10 @@
             <li class="notification-item" data-name="Kimberly Smith">
               <img class="notification-profile" src="assets/images/avatar-kimberly-smith.webp" width="50px" height="50px" alt="Kimberly Smith's profile picture" />
               <div class="notification-content">
-                <p class="notification-title"><a>Kimberly Smith</a> commented on your picture</p>
+                <p class="notification-title">
+                  <a>Kimberly Smith</a>
+                  commented on your picture
+                </p>
                 <p class="notification-description">1 week ago</p>
               </div>
               <div class="notification-image">
@@ -69,7 +90,11 @@
               <img class="notification-profile" src="assets/images/avatar-nathan-peterson.webp" width="50px" height="50px" />
               <div class="notification-content">
                 <div class="notification-content">
-                  <p class="notification-title"><a>Nathan Peterson</a> reacted to your recent post <a>5 end-game strategies to increase your win rate</a></p>
+                  <p class="notification-title">
+                    <a>Nathan Peterson</a>
+                    reacted to your recent post
+                    <a>5 end-game strategies to increase your win rate</a>
+                  </p>
                   <p class="notification-description">2 weeks ago</p>
                 </div>
               </div>
@@ -77,7 +102,11 @@
             <li class="notification-item" data-name="Anna Kim">
               <img class="notification-profile" src="assets/images/avatar-anna-kim.webp" width="50px" height="50px" />
               <div class="notification-content">
-                <p class="notification-title"><a>Anna Kim</a> left the group <a class="group-link">Chess Club</a></p>
+                <p class="notification-title">
+                  <a>Anna Kim</a>
+                  left the group
+                  <a class="group-link">Chess Club</a>
+                </p>
                 <p class="notification-description">2 weeks ago</p>
               </div>
             </li>
@@ -88,5 +117,6 @@
     <footer></footer>
 
     <script src="docs/app.js"></script>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/order_summary_component/index.html
+++ b/public/projects/frontend_mentor/order_summary_component/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -6,10 +6,7 @@
     <!-- displays site properly based on user's device -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@500;700;900&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@500;700;900&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="tailwind.config.js" />
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
     <script>
@@ -27,82 +24,49 @@
         },
       };
     </script>
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="./css/general-styles.css" />
     <title>Frontend Mentor | Order summary card</title>
   </head>
-  <body
-    class="flex flex-col justify-center content-center min-h-screen bg-top bg-pale-blue p-6"
-  >
+  <body class="flex flex-col justify-center content-center min-h-screen bg-top bg-pale-blue p-6">
     <main>
       <!-- Card Container -->
-      <div
-        class="flex flex-col max-w-md mx-auto rounded-xl shadow-md overflow-hidden bg-white"
-      >
+      <div class="flex flex-col max-w-md mx-auto rounded-xl shadow-md overflow-hidden bg-white">
         <!-- Card Image -->
-        <img
-          class="mb-12"
-          src="./images/illustration-hero.svg"
-          alt="Hero Illustration"
-        />
+        <img class="mb-12" src="./images/illustration-hero.svg" alt="Hero Illustration" />
         <!-- Card Layout -->
         <div class="flex flex-col items-center px-12">
           <!-- Card Header -->
-          <h1
-            class="font-black text-center text-dark-blue tracking-wide text-2xl mb-6"
-          >
-            Order Summary
-          </h1>
+          <h1 class="font-black text-center text-dark-blue tracking-wide text-2xl mb-6">Order Summary</h1>
           <!-- Card Body  -->
-          <p class="text-center text-lg text-desaturated-blue mb-4 px-6">
-            You can now listen millions of songs, audiobooks, and podcasts on
-            any device anywhere you like!
-          </p>
+          <p class="text-center text-lg text-desaturated-blue mb-4 px-6">You can now listen millions of songs, audiobooks, and podcasts on any device anywhere you like!</p>
           <!-- Plan Layout  -->
-          <div
-            class="flex flex-1 flex-wrap flex-start items-center bg-very-pale-blue rounded-xl w-full py-6 justify-center mb-8 col-to-row"
-          >
+          <div class="flex flex-1 flex-wrap flex-start items-center bg-very-pale-blue rounded-xl w-full py-6 justify-center mb-8 col-to-row">
             <img class="mr-4" src="./images/icon-music.svg" alt="Music Icon" />
             <div class="flex flex-col basis-1/2 col-to-row font-bold">
               Annual Plan
               <div class="font-medium text-desaturated-blue">$59.99/year</div>
             </div>
-            <a
-              href="#"
-              class="text-sm basis-1/4 underline font-bold text-bright-blue hover:text-pale-blue cursor-pointer"
-              >Change</a
-            >
+            <a href="#" class="text-sm basis-1/4 underline font-bold text-bright-blue hover:text-pale-blue cursor-pointer">Change</a>
           </div>
           <!-- Proceed to payment button  -->
-          <a
-            href="#"
-            class="bg-bright-blue text-center shadow-sm shadow-bright-blue font-bold text-white text-sm p-3 w-[100%] rounded-lg mb-8 cursor-pointer hover:bg-pale-blue"
-          >
-            Proceed to Payment
-          </a>
+          <a href="#" class="bg-bright-blue text-center shadow-sm shadow-bright-blue font-bold text-white text-sm p-3 w-[100%] rounded-lg mb-8 cursor-pointer hover:bg-pale-blue">Proceed to Payment</a>
           <!-- Cancel order -->
-          <div
-            class="text-desaturated-blue font-bold mb-12 hover:text-dark-blue cursor-pointer"
-          >
-            Cancel Order
-          </div>
+          <div class="text-desaturated-blue font-bold mb-12 hover:text-dark-blue cursor-pointer">Cancel Order</div>
         </div>
       </div>
       <div class="getouttahere">
         <div class="attribution">
           Challenge by
-          <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-            >Frontend Mentor</a
-          >. Coded by <a href="#">Colin McArthur </a>.
+          <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+          . Coded by
+          <a href="#">Colin McArthur</a>
+          .
         </div>
       </div>
     </main>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/order_summary_component/index.html
+++ b/public/projects/frontend_mentor/order_summary_component/index.html
@@ -28,9 +28,11 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="./css/general-styles.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <title>Frontend Mentor | Order summary card</title>
   </head>
   <body class="flex flex-col justify-center content-center min-h-screen bg-top bg-pale-blue p-6">
+    <div id="menu-container"></div>
     <main>
       <!-- Card Container -->
       <div class="flex flex-col max-w-md mx-auto rounded-xl shadow-md overflow-hidden bg-white">

--- a/public/projects/frontend_mentor/pricingblock/index.html
+++ b/public/projects/frontend_mentor/pricingblock/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!-- 15:30 in the video -->
 <html lang="en">
   <head>
@@ -6,17 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/pricingblock/CSS/style.css" />
     <title>Frontend Mentor | Single Price Grid Component</title>
 
@@ -32,19 +24,19 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <section class="price">
       <div class="community">
         <h2>Join our community</h2>
         <div class="subtitle">30-day, hassle-free money back guarantee</div>
-        <p>
-          Gain access to our full library of tutorials along with expert code
-          reviews. Perfect for any developers who are serious about honing their
-          skills.
-        </p>
+        <p>Gain access to our full library of tutorials along with expert code reviews. Perfect for any developers who are serious about honing their skills.</p>
       </div>
       <div class="subscription">
         <h3>Monthly Subscription</h3>
-        <div class="subscription__price">&dollar;29<span>per month</span></div>
+        <div class="subscription__price">
+          &dollar;29
+          <span>per month</span>
+        </div>
         <p>Full access for less than &dollar;1 a day</p>
         <a href="#">Sign Up</a>
       </div>
@@ -66,10 +58,12 @@
     <footer>
       <p class="attribution">
         Challenge by
-        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-          >Frontend Mentor</a
-        >. Coded by <a href="#">Colin McArthur</a>.
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Colin McArthur</a>
+        .
       </p>
     </footer>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/pricingblock/index.html
+++ b/public/projects/frontend_mentor/pricingblock/index.html
@@ -10,6 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link href="https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/pricingblock/CSS/style.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <title>Frontend Mentor | Single Price Grid Component</title>
 
     <!-- Feel free to remove these styles or customise in your own stylesheet 👍 -->

--- a/public/projects/frontend_mentor/product_preview_card/docs/index.html
+++ b/public/projects/frontend_mentor/product_preview_card/docs/index.html
@@ -1,30 +1,19 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,700&display=swap" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;700&display=swap" rel="stylesheet" />
     <title>Frontend Mentor | Product preview card component</title>
 
     <!-- Feel free to remove these styles or customise in your own stylesheet 👍 -->
@@ -39,27 +28,24 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <article>
         <div class="card">
           <!-- <div class="card__img"> -->
-            <img class="card__img" src="images/image-product-desktop.jpg" alt="" />
+          <img class="card__img" src="images/image-product-desktop.jpg" alt="" />
           <!-- </div> -->
           <div class="card__content">
             <p class="card__content-perfume">Perfume</p>
             <h2 class="card__content-title">Gabrielle Essence Eau De Parfum</h2>
-            <p class="card__content-body">
-              A floral, solar and voluptuous interpretation composed by Olivier
-              Polge, Perfumer-Creator for the House of CHANEL.
-            </p>
+            <p class="card__content-body">A floral, solar and voluptuous interpretation composed by Olivier Polge, Perfumer-Creator for the House of CHANEL.</p>
             <div class="card__price">
               <div class="card__price-left">$149.99</div>
               <div class="card__price-right">$169.99</div>
             </div>
             <button>
-              <img src="images/icon-cart.svg" class="card__btn-icon"></img>
+              <img src="images/icon-cart.svg" class="card__btn-icon" />
               <div class="card__btn-text">Add to cart</div>
-            
             </button>
           </div>
         </div>
@@ -68,10 +54,12 @@
     <footer>
       <div class="attribution">
         Challenge by
-        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-          >Frontend Mentor</a
-        >. Coded by <a href="https://github.com/ColinMcArthur85">Colin McArthur</a>.
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="https://github.com/ColinMcArthur85">Colin McArthur</a>
+        .
       </div>
     </footer>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/product_preview_card/docs/index.html
+++ b/public/projects/frontend_mentor/product_preview_card/docs/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/normalize.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,700&display=swap" rel="stylesheet" />

--- a/public/projects/frontend_mentor/profile_card/docs/index.html
+++ b/public/projects/frontend_mentor/profile_card/docs/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/normalize.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;700&display=swap" rel="stylesheet" />

--- a/public/projects/frontend_mentor/profile_card/docs/index.html
+++ b/public/projects/frontend_mentor/profile_card/docs/index.html
@@ -1,24 +1,16 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/normalize.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css2?family=Kumbh+Sans:wght@400;700&display=swap" rel="stylesheet" />
 
     <title>Frontend Mentor | Profile card component</title>
 
@@ -34,24 +26,19 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <article>
         <div class="card">
           <div class="card__top">
             <picture>
-              <source
-                media="(min-width:100%)"
-                srcset="images/bg-pattern-card.svg"
-              />
+              <source media="(min-width:100%)" srcset="images/bg-pattern-card.svg" />
               <img src="images/bg-pattern-card.svg" alt="circle patterns" />
             </picture>
           </div>
           <div class="card__middle">
             <picture>
-              <source
-                media="(min-width:100%)"
-                srcset="images/image-victor.jpg"
-              />
+              <source media="(min-width:100%)" srcset="images/image-victor.jpg" />
               <img src="images/image-victor.jpg" alt="circle patterns" />
             </picture>
           </div>
@@ -82,10 +69,12 @@
     <footer>
       <div class="attribution">
         Challenge by
-        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-          >Frontend Mentor</a
-        >. Coded by <a href="#">Colin McArthur</a>.
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Colin McArthur</a>
+        .
       </div>
     </footer>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/qr_code/index.html
+++ b/public/projects/frontend_mentor/qr_code/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -10,6 +10,7 @@
     <title>QR Code Component - Colin McArthur</title>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <div class="card__container">
         <div class="card__items">
@@ -19,14 +20,12 @@
               <h1>Improve your front-end skills by building projects</h1>
             </div>
             <div class="card__body">
-              <p>
-                Scan the QR code to visit Frontend Mentor and take your coding
-                skills to the next level
-              </p>
+              <p>Scan the QR code to visit Frontend Mentor and take your coding skills to the next level</p>
             </div>
           </div>
         </div>
       </div>
     </main>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/qr_code/index.html
+++ b/public/projects/frontend_mentor/qr_code/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="CSS/global-styles.css" />
     <link rel="stylesheet" href="CSS/style.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <link rel="icon" href="images/image-qr-code.png" />
     <title>QR Code Component - Colin McArthur</title>
   </head>

--- a/public/projects/frontend_mentor/results_summary/index.html
+++ b/public/projects/frontend_mentor/results_summary/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -9,6 +9,7 @@
   </head>
 
   <body>
+    <div id="menu-container"></div>
     <section class="results">
       <article class="results__summary gradient--light-slate-to-light-royal">
         <h2 class="results__title">Your Result</h2>
@@ -43,7 +44,14 @@
     </section>
 
     <footer>
-      <div class="attribution">Challenge by <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>. Coded by <a href="#">Your Name Here</a>.</div>
+      <div class="attribution">
+        Challenge by
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Your Name Here</a>
+        .
+      </div>
     </footer>
+    <script src="../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/results_summary/index.html
+++ b/public/projects/frontend_mentor/results_summary/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" sizes="32x32" href="./assets/images/favicon-32x32.png" />
     <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="../../../assets/css/style.css" />
     <title>Frontend Mentor | Results summary component</title>
   </head>
 

--- a/public/projects/frontend_mentor/social_proof/docs/index.html
+++ b/public/projects/frontend_mentor/social_proof/docs/index.html
@@ -7,6 +7,7 @@
 
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="/docs/css/styles.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
     <title>Frontend Mentor | Social proof section</title>
 
     <!-- Feel free to remove these styles or customise in your own stylesheet 👍 -->
@@ -101,15 +102,15 @@
         </div>
       </article>
     </main>
+    <footer>
+      <div class="attribution">
+        Challenge by
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Colin McArthur</a>
+        .
+      </div>
+    </footer>
     <script src="../../../../assets/js/components/header.js"></script>
   </body>
-  <footer>
-    <div class="attribution">
-      Challenge by
-      <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
-      . Coded by
-      <a href="#">Colin McArthur</a>
-      .
-    </div>
-  </footer>
 </html>

--- a/public/projects/frontend_mentor/social_proof/docs/index.html
+++ b/public/projects/frontend_mentor/social_proof/docs/index.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="/docs/css/styles.css" />
     <title>Frontend Mentor | Social proof section</title>
 
@@ -26,106 +21,43 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <main>
       <article>
         <div class="container">
           <div class="even-columns">
             <div class="intro flow">
               <h2>10,000+ of our users love our products.</h2>
-              <p>
-                We only provide great products combined with excellent customer
-                service. See what our satisfied customers are saying about our
-                services.
-              </p>
+              <p>We only provide great products combined with excellent customer service. See what our satisfied customers are saying about our services.</p>
             </div>
             <div class="reviews flow">
               <div class="review flow left-top">
                 <div class="review-icons">
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
                 </div>
                 <p class="review-rating">Rated 5 Stars in Reviews</p>
               </div>
               <div class="review flow left-mid">
                 <div class="review-icons flow-r">
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
                 </div>
                 <p class="review-rating">Rated 5 Stars in Report Guru</p>
               </div>
               <div class="review flow">
                 <div class="review-icons flow-r">
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
-                  <img
-                    class="review-icon"
-                    src="/docs/images/icon-star.svg"
-                    data-type="star-icon"
-                  />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
+                  <img class="review-icon" src="/docs/images/icon-star.svg" data-type="star-icon" />
                 </div>
                 <p class="review-rating">Rated 5 Stars in BestTech</p>
               </div>
@@ -134,73 +66,50 @@
           <div class="cards even-columns flow">
             <div class="card up">
               <div class="card-profile">
-                <img
-                  class="profile-image"
-                  src="/docs/images/image-colton.jpg"
-                  alt="Colton Smith Profile Photo"
-                  data-type="profile-headshot"
-                />
+                <img class="profile-image" src="/docs/images/image-colton.jpg" alt="Colton Smith Profile Photo" data-type="profile-headshot" />
                 <div class="flex">
                   <h3 class="profile-name">Colton Smith</h3>
                   <h4 class="profile-buyer">Verified Buyer</h4>
                 </div>
               </div>
               <p class="card-body">
-                "We needed the same printed design as the one we had ordered a
-                week prior. Not only did they find the original order, but we
-                also received it in time. Excellent!"
+                "We needed the same printed design as the one we had ordered a week prior. Not only did they find the original order, but we also received it in time. Excellent!"
               </p>
             </div>
             <div class="card">
               <div class="card-profile">
-                <img
-                  class="profile-image"
-                  src="/docs/images/image-irene.jpg"
-                  alt="Irene Roberts Profile Photo"
-                  data-type="profile-headshot"
-                />
+                <img class="profile-image" src="/docs/images/image-irene.jpg" alt="Irene Roberts Profile Photo" data-type="profile-headshot" />
                 <div class="flex">
                   <h3 class="profile-name">Irene Roberts</h3>
                   <h4 class="profile-buyer">Verified Buyer</h4>
                 </div>
               </div>
-              <p class="card-body">
-                "Customer service is always excellent and very quick turn
-                around. Completely delighted with the simplicity of the purchase
-                and the speed of delivery."
-              </p>
+              <p class="card-body">"Customer service is always excellent and very quick turn around. Completely delighted with the simplicity of the purchase and the speed of delivery."</p>
             </div>
 
             <div class="card down">
               <div class="card-profile">
-                <img
-                  class="profile-image"
-                  src="/docs/images/image-anne.jpg"
-                  alt="Anne Wallace Profile Photo"
-                  data-type="profile-headshot"
-                />
+                <img class="profile-image" src="/docs/images/image-anne.jpg" alt="Anne Wallace Profile Photo" data-type="profile-headshot" />
                 <div class="flex">
                   <h3 class="profile-name">Anne Wallace</h3>
                   <h4 class="profile-buyer">Verified Buyer</h4>
                 </div>
               </div>
-              <p class="card-body">
-                "Put an order with this company and can only praise them for the
-                very high standard. Will definitely use them again and recommend
-                them to everyone!"
-              </p>
+              <p class="card-body">"Put an order with this company and can only praise them for the very high standard. Will definitely use them again and recommend them to everyone!"</p>
             </div>
           </div>
         </div>
       </article>
     </main>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
   <footer>
     <div class="attribution">
       Challenge by
-      <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-        >Frontend Mentor</a
-      >. Coded by <a href="#">Colin McArthur</a>.
+      <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+      . Coded by
+      <a href="#">Colin McArthur</a>
+      .
     </div>
   </footer>
 </html>

--- a/public/projects/frontend_mentor/stats_card/public/index.html
+++ b/public/projects/frontend_mentor/stats_card/public/index.html
@@ -1,16 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- displays site properly based on user's device -->
 
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="32x32"
-      href="./images/favicon-32x32.png"
-    />
+    <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/normalize.css" />
 
@@ -28,17 +23,16 @@
     </style>
   </head>
   <body>
+    <div id="menu-container"></div>
     <section>
       <div class="card">
         <div class="card__content">
           <h2 class="card__content-heading">
-            Get <span class="accent">insights</span> that help your business
-            grow.
+            Get
+            <span class="accent">insights</span>
+            that help your business grow.
           </h2>
-          <p class="card__content-body">
-            Discover the benefits of data analytics and make better decisions
-            regarding revenue, customer experience, and overall efficiency.
-          </p>
+          <p class="card__content-body">Discover the benefits of data analytics and make better decisions regarding revenue, customer experience, and overall efficiency.</p>
           <div class="card__content-stats">
             <div class="flex-col">
               <div class="stats-heading">10k+</div>
@@ -60,10 +54,12 @@
       </div>
       <div class="attribution">
         Challenge by
-        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank"
-          >Frontend Mentor</a
-        >. Coded by <a href="#">Colin McArthur</a>.
+        <a href="https://www.frontendmentor.io?ref=challenge" target="_blank">Frontend Mentor</a>
+        . Coded by
+        <a href="#">Colin McArthur</a>
+        .
       </div>
     </section>
+    <script src="../../../../assets/js/components/header.js"></script>
   </body>
 </html>

--- a/public/projects/frontend_mentor/stats_card/public/index.html
+++ b/public/projects/frontend_mentor/stats_card/public/index.html
@@ -8,6 +8,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="./images/favicon-32x32.png" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/normalize.css" />
+    <link rel="stylesheet" href="../../../../assets/css/style.css" />
 
     <title>Stats preview card component 1</title>
 

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -6,7 +6,11 @@
     "image": "../projects/frontend_mentor/3_column_preview_card/design/desktop-preview.jpg",
     "live": "../projects/frontend_mentor/3_column_preview_card/public/index.html",
     "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/3_column_preview_card",
-    "tags": ["HTML5", "CSS3", "SASS"],
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
     "category": "Frontend Mentor"
   },
   {
@@ -16,7 +20,10 @@
     "image": "../projects/frontend_mentor/equalizer_landing_page/Images/preview.jpg",
     "live": "../projects/frontend_mentor/equalizer_landing_page/index.html",
     "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/equalizer_landing_page",
-    "tags": ["HTML5", "CSS3"],
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
     "category": "Frontend Mentor"
   },
   {
@@ -26,7 +33,175 @@
     "image": "../projects/frontend_mentor/four_card_feature/public/images/Four Card Feature SCreesnhot.png",
     "live": "../projects/frontend_mentor/four_card_feature/index.html",
     "code": "#",
-    "tags": ["HTML5", "CSS3", "SASS"],
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "huddle-landing-page",
+    "title": "Huddle Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/huddle_landing_page/docs/images/Huddle%20Landing%20Page.png",
+    "live": "../projects/frontend_mentor/huddle_landing_page/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/huddle_landing_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "meeting-landing-page",
+    "title": "Meeting Landing Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/meeting_landing_page/public/assets/Meet%20Landing%20Page%20Final.png",
+    "live": "../projects/frontend_mentor/meeting_landing_page/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/meeting_landing_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "nft-card",
+    "title": "NFT Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/nft_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/nft_card/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/nft_card",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "notifications-page",
+    "title": "Notifications Page",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/notifications_page/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/notifications_page/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/notifications_page",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "order-summary-component",
+    "title": "Order Summary Component",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/order_summary_component/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/order_summary_component/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/order_summary_component",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "pricingblock",
+    "title": "Pricing Block",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "https://via.placeholder.com/300x200?text=Pricing%20Block",
+    "live": "../projects/frontend_mentor/pricingblock/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/pricingblock",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "product-preview-card",
+    "title": "Product Preview Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/product_preview_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/product_preview_card/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/product_preview_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "profile-card",
+    "title": "Profile Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/profile_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/profile_card/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/profile_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "qr-code",
+    "title": "QR Code",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/qr_code/Desktop.png",
+    "live": "../projects/frontend_mentor/qr_code/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/qr_code",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "results-summary",
+    "title": "Results Summary",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/results_summary/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/results_summary/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/results_summary",
+    "tags": [
+      "HTML5",
+      "CSS3"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "social-proof",
+    "title": "Social Proof",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/social_proof/src/assets/Layouts/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/social_proof/docs/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/social_proof",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
+    "category": "Frontend Mentor"
+  },
+  {
+    "id": "stats-card",
+    "title": "Stats Card",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam id massa eros. Donec et rutrum elit.",
+    "image": "../projects/frontend_mentor/stats_card/design/desktop-preview.jpg",
+    "live": "../projects/frontend_mentor/stats_card/public/index.html",
+    "code": "https://github.com/ColinMcArthur85/devsite/tree/main/public/projects/frontend_mentor/stats_card",
+    "tags": [
+      "HTML5",
+      "CSS3",
+      "SASS"
+    ],
     "category": "Frontend Mentor"
   }
 ]

--- a/src/js/projects.js
+++ b/src/js/projects.js
@@ -3,6 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const paginationContainer = document.getElementById("pagination");
   const techFilterContainer = document.getElementById("filter-tech");
   const categoryFilterContainer = document.getElementById("filter-category");
+  const resultsCount = document.getElementById("results-count");
 
   const storageKey = "projectFilters";
   let stored = {};
@@ -48,8 +49,15 @@ document.addEventListener("DOMContentLoaded", () => {
       function applyFilters() {
         if (selectedCategories.size === 0 && selectedTech.size === 0) {
           filtered = [];
+          if (resultsCount) resultsCount.textContent = "";
         } else {
-          filtered = projects.filter((p) => (selectedCategories.size === 0 || selectedCategories.has(p.category)) && (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))));
+          filtered = projects.filter(
+            (p) =>
+              (selectedCategories.size === 0 || selectedCategories.has(p.category)) &&
+              (selectedTech.size === 0 || [...selectedTech].some((t) => p.tags.includes(t))),
+          );
+          if (resultsCount)
+            resultsCount.textContent = `${filtered.length} project${filtered.length === 1 ? "" : "s"} found`;
         }
         currentPage = 1;
         renderPage();


### PR DESCRIPTION
## Summary
- add remaining Frontend Mentor challenges to project data
- wire up project pages with menu container and header script
- remove binary preview image from Pricing Block project and use external placeholder

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a63a01d9648326b64ac0767d724f18