### PR TITLE
Refactor homepage cards and icon interactions

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1676,6 +1676,14 @@
       }
     }
   }
+  .group-hover\:shadow-2xl {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
+        box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+      }
+    }
+  }
   .hover\:-translate-y-1 {
     &:hover {
       @media (hover: hover) {
@@ -2260,7 +2268,7 @@ p {
   }
 }
 @layer components {
-  .card {
+  .primary-card {
     position: relative;
     overflow: hidden;
     border-radius: var(--radius-3xl);
@@ -2299,7 +2307,7 @@ p {
     }
     isolation: isolate;
   }
-  .card::before {
+  .primary-card::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -2309,21 +2317,56 @@ p {
     pointer-events: none;
     z-index: 0;
   }
-  .dark .card::before {
+  .dark .primary-card::before {
     background: linear-gradient(135deg, rgba(96, 165, 250, 0.16) 0%, rgba(15, 23, 42, 0.7) 55%, rgba(124, 58, 237, 0.22) 100%);
   }
-  .card:hover::before {
+  .primary-card:hover::before {
     opacity: 1;
   }
-  .card > * {
+  .primary-card > * {
     position: relative;
     z-index: 1;
   }
-  .card:hover {
+  .primary-card:hover {
     --tw-translate-y: calc(var(--spacing) * -1);
     translate: var(--tw-translate-x) var(--tw-translate-y);
     --tw-shadow: 0 25px 50px -12px var(--tw-shadow-color, rgb(0 0 0 / 0.25));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .secondary-card {
+    border-radius: var(--radius-3xl);
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+    border-color: color-mix(in srgb, #fff 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 30%, transparent);
+    }
+    background-color: color-mix(in srgb, #fff 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+    --tw-shadow: 0 20px 25px -5px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 8px 10px -6px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    --tw-backdrop-blur: blur(var(--blur-lg));
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    --tw-duration: 500ms;
+    transition-duration: 500ms;
+    &:where(.dark, .dark *) {
+      border-color: color-mix(in srgb, #fff 10%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+      }
+    }
+    &:where(.dark, .dark *) {
+      background-color: color-mix(in srgb, #fff 5%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-white) 5%, transparent);
+      }
+    }
   }
   .card-icon {
     position: relative;

--- a/public/components/menu.html
+++ b/public/components/menu.html
@@ -4,7 +4,7 @@
     <nav class="navbar relative p-6">
       <a href="{{BASE_PATH}}index.html" class="group flex items-center gap-4">
         <span
-          class="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-indigo-500 to-secondary text-base font-bold text-white shadow-lg transition-transform duration-300 group-hover:-translate-y-1"
+          class="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-indigo-500 to-secondary text-base font-bold text-white shadow-lg transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-2xl"
         >
           CM
         </span>
@@ -36,7 +36,7 @@
           class="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 bg-white/20 text-slate-600 transition-all duration-300 hover:-translate-y-1 hover:text-primary dark:border-white/10 dark:bg-white/10 dark:text-slate-300"
           aria-label="Switch theme"
         >
-          <i class="fa-solid fa-moon text-base"></i>
+          <i class="fa-solid fa-moon text-base boop"></i>
         </button>
         <button
           id="menuToggle"
@@ -68,7 +68,7 @@
         class="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-slate-200 transition-all duration-300 hover:-translate-y-1 hover:text-white"
         aria-label="Close navigation"
       >
-        <i class="fa-solid fa-xmark text-2xl"></i>
+        <i class="fa-solid fa-xmark text-2xl boop"></i>
       </button>
     </div>
     <ul class="mt-16 flex flex-1 flex-col items-center justify-center gap-8 text-center">
@@ -93,13 +93,13 @@
     </ul>
     <div class="mt-12 flex justify-center gap-4">
       <a href="https://github.com/ColinMcArthur85" class="social-btn" aria-label="GitHub">
-        <i class="fa-brands fa-github"></i>
+        <i class="fa-brands fa-github boop"></i>
       </a>
       <a href="https://www.linkedin.com" class="social-btn" aria-label="LinkedIn">
-        <i class="fa-brands fa-linkedin-in"></i>
+        <i class="fa-brands fa-linkedin-in boop"></i>
       </a>
       <a href="https://twitter.com" class="social-btn" aria-label="Twitter">
-        <i class="fa-brands fa-x-twitter"></i>
+        <i class="fa-brands fa-x-twitter boop"></i>
       </a>
     </div>
   </div>

--- a/public/data/skills.json
+++ b/public/data/skills.json
@@ -1,6 +1,6 @@
 {
   "HTML": 5327,
-  "CSS": 4563,
+  "CSS": 4567,
   "SASS": 2299,
   "JavaScript": 950,
   "PHP": 0,

--- a/public/index.html
+++ b/public/index.html
@@ -202,7 +202,7 @@
               <div class="mt-6 flex flex-col gap-3 rounded-2xl border border-white/40 bg-white/80 p-5 shadow-lg backdrop-blur-lg dark:border-white/10 dark:bg-white/10">
                 <div class="flex items-center gap-3">
                   <span class="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
-                    <i class="fa-solid fa-wand-magic-sparkles text-lg"></i>
+                    <i class="fa-solid fa-wand-magic-sparkles text-lg boop"></i>
                   </span>
                   <div>
                     <p class="text-sm font-semibold text-gray-900 dark:text-white">Realtime Systems</p>
@@ -233,7 +233,7 @@
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           <!-- Feature Card 1: Front-End Development -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-laptop-code text-xl boop"></i>
@@ -245,7 +245,7 @@
           </div>
 
           <!-- Feature Card 2: Infrastructure & Ops -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-server text-xl boop"></i>
@@ -257,7 +257,7 @@
           </div>
 
           <!-- Feature Card 3: AI Workflow Integration -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-robot text-xl boop"></i>
@@ -269,7 +269,7 @@
           </div>
 
           <!-- Feature Card 4: Project Structure -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-folder-tree text-xl boop"></i>
@@ -281,7 +281,7 @@
           </div>
 
           <!-- Feature Card 5: Problem Solving -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-magnifying-glass-chart text-xl boop"></i>
@@ -293,7 +293,7 @@
           </div>
 
           <!-- Feature Card 6: Building Toward -->
-          <div class="card">
+          <div class="primary-card">
             <div class="absolute inset-0 bg-gradient-to-br from-primary/20 via-transparent to-secondary/30 opacity-0 transition-opacity duration-500 group-hover:opacity-100"></div>
             <div class="relative z-10 flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary to-secondary text-white shadow-lg">
               <i class="fa-solid fa-person-running text-xl boop"></i>
@@ -318,7 +318,7 @@
         <div class="grid grid-cols-1 gap-16 lg:grid-cols-[1.15fr_0.85fr]">
           <div class="space-y-10 text-gray-900 dark:text-white">
             <h2 class="section-title text-left text-4xl font-semibold">About Me</h2>
-            <div class="rounded-3xl border border-white/30 bg-white/80 p-8 shadow-xl backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+            <div class="secondary-card p-8">
               <div class="space-y-6 text-lg leading-relaxed text-gray-700 dark:text-gray-200">
                 <p>
                   For most of my life, I believed software development was for other people — people smarter than me, younger than me, more mathematically wired than me. I used to think I'd never
@@ -358,7 +358,7 @@
             </div>
           </div>
           <div class="flex flex-col gap-6">
-            <div class="rounded-3xl border border-white/30 bg-white/80 p-6 shadow-xl backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+            <div class="secondary-card p-6">
               <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Currently Building</h3>
               <ul class="mt-4 space-y-4 text-sm leading-relaxed text-gray-600 dark:text-gray-300">
                 <li class="flex items-start gap-3">
@@ -375,7 +375,7 @@
                 </li>
               </ul>
             </div>
-            <div class="rounded-3xl border border-white/30 bg-white/80 p-6 shadow-xl backdrop-blur-lg dark:border-white/10 dark:bg-white/5">
+            <div class="secondary-card p-6">
               <h3 class="text-lg font-semibold text-gray-900 dark:text-white">Operating Principles</h3>
               <div class="mt-4 grid gap-4 text-sm text-gray-600 dark:text-gray-300">
                 <div class="rounded-2xl border border-white/30 bg-white/80 p-4 shadow-md backdrop-blur-sm dark:border-white/10 dark:bg-white/10">
@@ -406,7 +406,7 @@
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
           <!-- Skills Card 1 -->
-          <div class="card" data-skill="HTML">
+          <div class="primary-card" data-skill="HTML">
             <div class="card-icon bg-[var(--color-html5)]/15">
               <svg class="w-8 h-8 text-[var(--color-html5)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -428,7 +428,7 @@
             <p class="lines-count text-xs text-neutral-800 dark:text-neutral-200 font-mono mt-1">0 lines</p>
           </div>
           <!-- Skills Card 2 -->
-          <div class="card" data-skill="CSS">
+          <div class="primary-card" data-skill="CSS">
             <div class="card-icon bg-[var(--color-css3)]/15 group transition-transform duration-300">
               <svg class="w-8 h-8 text-[var(--color-css3)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -450,7 +450,7 @@
             <p class="lines-count text-xs text-neutral-800 dark:text-neutral-200 font-mono mt-1">0 lines</p>
           </div>
           <!-- Skills Card 3 -->
-          <div class="card" data-skill="SASS">
+          <div class="primary-card" data-skill="SASS">
             <div class="card-icon bg-[var(--color-sass-pink)]/15 group transition-transform duration-300">
               <svg class="w-8 h-8 text-[var(--color-sass-pink)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -473,7 +473,7 @@
           </div>
 
           <!-- Skills Card 4 -->
-          <div class="card" data-skill="JavaScript">
+          <div class="primary-card" data-skill="JavaScript">
             <div class="card-icon bg-[var(--color-javascript)]/15 group transition-transform duration-300">
               <svg class="w-8 h-8 text-[var(--color-javascript)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -496,7 +496,7 @@
           </div>
 
           <!-- Skills Card 5 -->
-          <div class="card" data-skill="PHP">
+          <div class="primary-card" data-skill="PHP">
             <div class="card-icon bg-[var(--color-php)]/15 group transition-transform duration-300">
               <svg class="w-8 h-8 text-[var(--color-php)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -518,7 +518,7 @@
           </div>
 
           <!-- Skills Card 6 -->
-          <div class="card" data-skill="MySQL">
+          <div class="primary-card" data-skill="MySQL">
             <div class="card-icon bg-[var(--color-mysql-orange)]/15 group transition-transform duration-300">
               <svg class="w-8 h-8 text-[var(--color-mysql-orange)] boop" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -555,7 +555,7 @@
 
         <div class="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-2 justify-center">
           <!-- Framework Card: Tailwind CSS -->
-          <div class="card" data-framework="Tailwind">
+          <div class="primary-card" data-framework="Tailwind">
             <div class="card-icon bg-[var(--color-tailwind-blue)]/15">
               <svg class="w-8 h-8 text-[var(--color-tailwind-blue)] boop" role="img" xmlns="http://www.w3.org/2000/svg">
                 <path
@@ -572,7 +572,7 @@
           </div>
 
           <!-- Framework Card: React -->
-          <div class="card mx-auto" data-framework="React">
+          <div class="primary-card mx-auto" data-framework="React">
             <div class="card-icon bg-[var(--color-react-blue)]/15">
               <svg class="boop" xmlns="http://www.w3.org/2000/svg" viewBox="-4 -4 40 40" fill="none">
                 <path
@@ -619,10 +619,10 @@
               business day.
             </p>
             <div class="grid gap-4 sm:grid-cols-2">
-              <div class="card p-6">
+              <div class="secondary-card p-6">
                 <div class="flex items-center gap-4">
                   <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
-                    <i class="fa-solid fa-envelope-open-text text-lg"></i>
+                    <i class="fa-solid fa-envelope-open-text text-lg boop"></i>
                   </span>
                   <div>
                     <p class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Email</p>
@@ -630,10 +630,10 @@
                   </div>
                 </div>
               </div>
-              <div class="card p-6">
+              <div class="secondary-card p-6">
                 <div class="flex items-center gap-4">
                   <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
-                    <i class="fa-solid fa-satellite-dish text-lg"></i>
+                    <i class="fa-solid fa-satellite-dish text-lg boop"></i>
                   </span>
                   <div>
                     <p class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Availability</p>
@@ -641,7 +641,7 @@
                   </div>
                 </div>
               </div>
-              <div class="card p-6 sm:col-span-2">
+              <div class="secondary-card p-6 sm:col-span-2">
                 <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Signal boosts</p>
@@ -649,13 +649,13 @@
                   </div>
                   <div class="flex gap-3">
                     <a href="https://github.com/ColinMcArthur85" class="social-btn" aria-label="GitHub">
-                      <i class="fa-brands fa-github"></i>
+                      <i class="fa-brands fa-github boop"></i>
                     </a>
                     <a href="https://www.linkedin.com" class="social-btn" aria-label="LinkedIn">
-                      <i class="fa-brands fa-linkedin-in"></i>
+                      <i class="fa-brands fa-linkedin-in boop"></i>
                     </a>
                     <a href="https://twitter.com" class="social-btn" aria-label="Twitter">
-                      <i class="fa-brands fa-x-twitter"></i>
+                      <i class="fa-brands fa-x-twitter boop"></i>
                     </a>
                   </div>
                 </div>
@@ -663,7 +663,7 @@
             </div>
           </div>
           <div>
-            <form id="contactForm" action="" class="card card-shadow flex flex-col gap-6 p-8">
+            <form id="contactForm" action="" class="secondary-card card-shadow flex flex-col gap-6 p-8">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Kickoff form</p>
                 <h3 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Tell me about the mission</h3>
@@ -712,14 +712,14 @@
                 href="mailto:hello@colin.codes"
                 class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition-colors duration-300 hover:bg-white/20"
               >
-                <i class="fa-solid fa-paper-plane"></i>
+                <i class="fa-solid fa-paper-plane boop"></i>
                 Email
               </a>
               <a
                 href="https://cal.com"
                 class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition-colors duration-300 hover:bg-white/20"
               >
-                <i class="fa-solid fa-calendar-plus"></i>
+                <i class="fa-solid fa-calendar-plus boop"></i>
                 Book a slot
               </a>
             </div>
@@ -741,13 +741,13 @@
               <p class="mt-5 text-sm text-slate-300">Follow ongoing builds and live ops updates.</p>
               <div class="mt-6 flex gap-4">
                 <a href="https://github.com/ColinMcArthur85" class="social-btn" aria-label="GitHub">
-                  <i class="fa-brands fa-github"></i>
+                  <i class="fa-brands fa-github boop"></i>
                 </a>
                 <a href="https://www.linkedin.com" class="social-btn" aria-label="LinkedIn">
-                  <i class="fa-brands fa-linkedin-in"></i>
+                  <i class="fa-brands fa-linkedin-in boop"></i>
                 </a>
                 <a href="https://twitter.com" class="social-btn" aria-label="Twitter">
-                  <i class="fa-brands fa-x-twitter"></i>
+                  <i class="fa-brands fa-x-twitter boop"></i>
                 </a>
               </div>
             </div>

--- a/public/pages/about.html
+++ b/public/pages/about.html
@@ -61,17 +61,17 @@
               </p>
             </div>
             <div class="grid gap-4 sm:grid-cols-3">
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Deployments</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">50+</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Shipping production-grade experiences since 2010</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Focus</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Human-led AI</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Copilots that amplify teams instead of replacing them</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Ops cadence</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Weekly</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Tight feedback loops + calm deployments</p>
@@ -165,12 +165,12 @@
                 </div>
               </div>
               <div class="mt-6 grid gap-4 sm:grid-cols-2">
-                <div class="card p-5">
+                <div class="primary-card p-5">
                   <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Base</p>
                   <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Vancouver, BC</p>
                   <p class="text-xs text-slate-500 dark:text-slate-400">Operating remotely with global teams</p>
                 </div>
-                <div class="card p-5">
+                <div class="primary-card p-5">
                   <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Stack</p>
                   <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Full-spectrum</p>
                   <p class="text-xs text-slate-500 dark:text-slate-400">Design systems, front-end, infra & automation</p>
@@ -198,7 +198,7 @@
           </p>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-layer-group text-xl"></i>
             </div>
@@ -207,7 +207,7 @@
               From naming conventions to observability dashboards, I design the invisible scaffolding that keeps teams shipping. Every component knows its role and how it degrades gracefully.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-sparkles text-xl"></i>
             </div>
@@ -216,7 +216,7 @@
               Interfaces should feel touchable. I use light, motion, and depth cues that respond to the human on the other side without sacrificing accessibility or performance budgets.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-brain-circuit text-xl"></i>
             </div>
@@ -225,7 +225,7 @@
               Copilots are embedded into product, ops, and support. They’re trained on your voice, your data, and your guardrails so they extend your team instead of guessing from the void.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-chart-line text-xl"></i>
             </div>
@@ -234,7 +234,7 @@
               Every release has KPIs attached—conversion, uptime, cycle time, satisfaction. Dashboards come standard so you can see the impact without digging through spreadsheets.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-handshake-angle text-xl"></i>
             </div>
@@ -243,7 +243,7 @@
               Async updates, live Looms, and shared command centers keep stakeholders synced. No black boxes—only clear intent and clear accountability.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-seedling text-xl"></i>
             </div>
@@ -273,7 +273,7 @@
           </p>
         </div>
         <div class="mt-16 grid gap-8 lg:grid-cols-2">
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">2025</span>
               <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
@@ -285,7 +285,7 @@
               Rebuilt my public presence as an experimental lab to showcase glassmorphism, procedural avatars, and AI-assisted content pipelines. Focused on accessibility, motion preferences, and zero-image hero assets.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">2023</span>
               <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
@@ -296,7 +296,7 @@
               Led DNS hardening, SSL automation, zero-downtime deploys, and synthetic monitoring rollout for a nationwide retail network. Reduced incident volume by 62% while improving deployment frequency.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">2021</span>
               <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">
@@ -307,7 +307,7 @@
               Built a GPT-powered triage partner that auto-tags tickets, suggests fixes, and populates runbooks. Reduced average response times by 34% and unlocked 24/7 coverage.
             </p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="flex items-center justify-between">
               <span class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">2015</span>
               <span class="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.25em] text-slate-500 dark:border-white/10 dark:bg-white/5 dark:text-slate-300">

--- a/public/pages/contact.html
+++ b/public/pages/contact.html
@@ -61,17 +61,17 @@
               </p>
             </div>
             <div class="grid gap-4 sm:grid-cols-3">
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Response time</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">&lt; 24 hrs</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">You'll hear from me within one business day</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Preferred channels</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Email & sync</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Asynchronous updates with optional live sessions</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Engagements</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Q2 slots</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Currently booking new collaborations for late spring</p>
@@ -83,7 +83,7 @@
             </div>
           </div>
           <div class="grid gap-6">
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <div class="flex items-center gap-4">
                 <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                   <i class="fa-solid fa-envelope-open-text text-lg"></i>
@@ -94,7 +94,7 @@
                 </div>
               </div>
             </div>
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <div class="flex items-center gap-4">
                 <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                   <i class="fa-solid fa-location-dot text-lg"></i>
@@ -105,7 +105,7 @@
                 </div>
               </div>
             </div>
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <div class="flex items-center gap-4">
                 <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                   <i class="fa-solid fa-waveform-lines text-lg"></i>
@@ -134,7 +134,7 @@
               Share the essentials: product stage, tech stack, timelines, and the outcomes you want. I'll map the build plan, identify quick wins, and highlight where AI or automation can accelerate the work.
             </p>
             <div class="grid gap-4">
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Included in your reply</h3>
                 <ul class="mt-4 space-y-2 text-sm text-slate-600 dark:text-slate-300">
                   <li class="flex items-start gap-3"><i class="fa-solid fa-check text-primary"></i> Suggested project milestones & risk notes</li>
@@ -142,7 +142,7 @@
                   <li class="flex items-start gap-3"><i class="fa-solid fa-check text-primary"></i> Next steps for kickoff or discovery call</li>
                 </ul>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Signal boosts</h3>
                 <div class="mt-4 flex flex-wrap gap-3">
                   <a href="https://github.com/ColinMcArthur85" class="social-btn" aria-label="GitHub">
@@ -159,7 +159,7 @@
             </div>
           </div>
           <div>
-            <form id="contactForm" action="" class="card card-shadow flex flex-col gap-6 p-8">
+            <form id="contactForm" action="" class="primary-card card-shadow flex flex-col gap-6 p-8">
               <div>
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Kickoff form</p>
                 <h3 class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Tell me about your mission</h3>
@@ -205,17 +205,17 @@
           <h2 class="mt-6 text-4xl font-semibold text-slate-900 dark:text-white">What happens after you reach out</h2>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-3">
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">T+0 hours</h3>
             <p class="mt-3 text-lg font-semibold text-slate-900 dark:text-white">Signal received</p>
             <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">You get an acknowledgement instantly. I review scope, timelines, and any supporting links.</p>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">T+24 hours</h3>
             <p class="mt-3 text-lg font-semibold text-slate-900 dark:text-white">Mission outline</p>
             <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Expect a tailored response with project milestones, toolchain suggestions, and first questions.</p>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">T+48 hours</h3>
             <p class="mt-3 text-lg font-semibold text-slate-900 dark:text-white">Launch prep</p>
             <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">We lock a kickoff call (if needed), spin up shared spaces, and begin building momentum.</p>

--- a/public/pages/projects.html
+++ b/public/pages/projects.html
@@ -66,15 +66,15 @@
             </div>
           </div>
           <div class="grid gap-4 sm:grid-cols-2">
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Launch types</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">SaaS platforms · marketing sites · AI copilots</p>
             </div>
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Toolchains</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">HTML, CSS, Tailwind, JS, PHP, MySQL, GPT APIs</p>
             </div>
-            <div class="card p-6 sm:col-span-2">
+            <div class="primary-card p-6 sm:col-span-2">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Recent highlights</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Procedural portfolio relaunch · Real-time observability dashboards · Conversational support assistant</p>
             </div>
@@ -90,7 +90,7 @@
       </div>
       <div class="container-wrapper relative z-10">
         <div class="grid gap-12 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
-          <aside class="card p-8">
+          <aside class="primary-card p-8">
             <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Signal filters</h2>
             <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Mix and match technologies or categories to surface the most relevant missions.</p>
             <div id="filter-container" class="mt-8 space-y-8">
@@ -131,7 +131,7 @@
           <p class="mt-4 text-base text-slate-600 dark:text-slate-300">Explorations and experiments that keep my toolkit sharp.</p>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">PHP session hardening</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
               Dialing in secure session storage, rotating tokens, and mitigating fixation. Building reference snippets for the ops playbook.
@@ -146,7 +146,7 @@
               <span>Logged: Jun 17, 2025</span>
             </div>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Native CSS nesting</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
               Refactoring older components to use native nesting with cascade layers. Cleaner semantics with less tooling overhead.
@@ -161,7 +161,7 @@
               <span>Logged: Jun 12, 2025</span>
             </div>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Component command center</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">
               Building JS-powered UI primitives with shared animation variables and accessible state machines.

--- a/public/pages/showcase.html
+++ b/public/pages/showcase.html
@@ -65,15 +65,15 @@
             </div>
           </div>
           <div class="grid gap-4 sm:grid-cols-2">
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Component kits</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Alerts, modals, dashboards, command palettes</p>
             </div>
-            <div class="card p-6">
+            <div class="primary-card p-6">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Animation library</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Cursor reactive lighting, parallax, procedural glows</p>
             </div>
-            <div class="card p-6 sm:col-span-2">
+            <div class="primary-card p-6 sm:col-span-2">
               <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Accessibility</p>
               <p class="mt-2 text-lg font-semibold text-slate-900 dark:text-white">Keyboard-first navigation, prefers-reduced-motion fallbacks, semantic HTML</p>
             </div>
@@ -96,42 +96,42 @@
           <p class="mt-4 text-base text-slate-600 dark:text-slate-300">Every project starts with a component library tailored to your brand and technical stack.</p>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-grid-2 text-xl"></i>
             </div>
             <h3 class="card-title">Responsive layout grids</h3>
             <p class="card-body">Adaptive column systems with fluid spacing tokens and container queries so everything snaps into place from mobile to ultrawide displays.</p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-rectangle-ad text-xl"></i>
             </div>
             <h3 class="card-title">Hero & storytelling blocks</h3>
             <p class="card-body">Immersive hero sections, testimonial carousels, and narrative timelines with layered lighting and motion.</p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-diagram-project text-xl"></i>
             </div>
             <h3 class="card-title">Admin dashboards</h3>
             <p class="card-body">Data visualizations, activity feeds, audit trails, and real-time alerts tuned for clarity and quick decision-making.</p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-comments text-xl"></i>
             </div>
             <h3 class="card-title">Support & knowledge bases</h3>
             <p class="card-body">AI-assisted triage, contextual FAQs, and searchable documentation that keep teams informed.</p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-robot text-xl"></i>
             </div>
             <h3 class="card-title">Automation launchpads</h3>
             <p class="card-body">Workflow builders, GPT prompt libraries, and integration hubs that let humans orchestrate complex systems effortlessly.</p>
           </article>
-          <article class="card p-8">
+          <article class="primary-card p-8">
             <div class="card-icon">
               <i class="fa-solid fa-vial-circle-check text-xl"></i>
             </div>
@@ -155,15 +155,15 @@
           <h2 class="mt-6 text-4xl font-semibold text-slate-900 dark:text-white">How we launch with confidence</h2>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-3">
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Interactive prototypes</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Figma, coded previews, or Storybook—choose the best medium for stakeholder feedback before development locks in.</p>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Accessibility audits</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">WCAG checks, keyboard navigation, screen-reader scripts, and dark-mode validations embedded in the QA process.</p>
           </article>
-          <article class="card p-6">
+          <article class="primary-card p-6">
             <h3 class="text-lg font-semibold text-slate-900 dark:text-white">Post-launch care</h3>
             <p class="mt-3 text-sm text-slate-600 dark:text-slate-300">Monitoring dashboards, incident runbooks, and iteration sprints to keep the experience fresh and stable.</p>
           </article>

--- a/public/pages/skills.html
+++ b/public/pages/skills.html
@@ -54,24 +54,24 @@
               </p>
             </div>
             <div class="grid gap-4 sm:grid-cols-3">
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Total lines</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">12,106</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Live data from the active repositories keeps this tally honest.</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Primary focus</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">Front-end systems</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">Component design, theming, animation, and accessibility.</p>
               </div>
-              <div class="card p-6">
+              <div class="primary-card p-6">
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">Ops & automation</p>
                 <p class="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">AI copilots</p>
                 <p class="text-xs text-slate-500 dark:text-slate-400">ChatGPT, embeddings, prompt engineering, workflow scripting.</p>
               </div>
             </div>
           </div>
-          <div class="card p-8">
+          <div class="primary-card p-8">
             <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Skill breakdown at a glance</h2>
             <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
               Percentages represent the share of code written in each language across active projects. The more lines in the wild, the sharper the reflexes.
@@ -104,7 +104,7 @@
           <p class="mt-4 text-base text-slate-600 dark:text-slate-300">These are the tools I reach for daily. Each card pulls live stats from the repository.</p>
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <article class="card p-8" data-skill="HTML">
+          <article class="primary-card p-8" data-skill="HTML">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-html5 text-xl"></i>
@@ -122,7 +122,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="CSS">
+          <article class="primary-card p-8" data-skill="CSS">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-css3-alt text-xl"></i>
@@ -140,7 +140,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="SASS">
+          <article class="primary-card p-8" data-skill="SASS">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-sass text-xl"></i>
@@ -158,7 +158,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="JavaScript">
+          <article class="primary-card p-8" data-skill="JavaScript">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-js text-xl"></i>
@@ -176,7 +176,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="PHP">
+          <article class="primary-card p-8" data-skill="PHP">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-php text-xl"></i>
@@ -194,7 +194,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="MySQL">
+          <article class="primary-card p-8" data-skill="MySQL">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-solid fa-database text-xl"></i>
@@ -212,7 +212,7 @@
               </div>
             </div>
           </article>
-          <article class="card p-8" data-skill="React">
+          <article class="primary-card p-8" data-skill="React">
             <div class="flex items-center gap-4">
               <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 text-primary shadow-lg">
                 <i class="fa-brands fa-react text-xl"></i>
@@ -251,7 +251,7 @@
         </div>
         <div class="mt-16 grid gap-8 md:grid-cols-3 lg:grid-cols-3">
           <!-- 1. Development & Programming -->
-          <article class="card p-6 card-shadow">
+          <article class="primary-card p-6 card-shadow">
             <h3 class="card-title">Development & Programming</h3>
 
             <h4 class="skill-heading">Languages & Frameworks</h4>
@@ -554,7 +554,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">AI & Automation</h3>
 
             <h4 class="skill-heading">Daily Usage</h4>
@@ -633,7 +633,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Technical Operations & Systems</h3>
 
             <h4 class="skill-heading">DNS & Domains</h4>
@@ -824,7 +824,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Marketing & Content</h3>
 
             <h4 class="skill-heading">Landing Pages & Funnels</h4>
@@ -931,7 +931,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Design</h3>
 
             <h4 class="skill-heading">Primary Tools</h4>
@@ -1043,7 +1043,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Product & Customer Support</h3>
             <ul class="ml-6 list-disc">
               <li>Freshdesk & Freshchat ticket mastery</li>
@@ -1054,7 +1054,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Education & Learning</h3>
             <ul class="ml-6 list-disc">
               <li>Multimedia Design & Communication diploma</li>
@@ -1066,7 +1066,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Projects & Labs</h3>
             <ul class="ml-6 list-disc">
               <li>AI Website Builder (Python + ChatGPT)</li>
@@ -1075,7 +1075,7 @@
             </ul>
           </article>
 
-          <article class="card card-shadow">
+          <article class="primary-card card-shadow">
             <h3 class="card-title">Software & Utilities</h3>
 
             <h4 class="skill-heading">Task & Ticketing</h4>

--- a/src/components/menu.html
+++ b/src/components/menu.html
@@ -4,7 +4,7 @@
     <nav class="navbar relative p-6">
       <a href="{{BASE_PATH}}index.html" class="group flex items-center gap-4">
         <span
-          class="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-indigo-500 to-secondary text-base font-bold text-white shadow-lg transition-transform duration-300 group-hover:-translate-y-1"
+          class="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-to-br from-primary via-indigo-500 to-secondary text-base font-bold text-white shadow-lg transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-2xl"
         >
           CM
         </span>
@@ -36,7 +36,7 @@
           class="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 bg-white/20 text-slate-600 transition-all duration-300 hover:-translate-y-1 hover:text-primary dark:border-white/10 dark:bg-white/10 dark:text-slate-300"
           aria-label="Switch theme"
         >
-          <i class="fa-solid fa-moon text-base"></i>
+          <i class="fa-solid fa-moon text-base boop"></i>
         </button>
         <button
           id="menuToggle"
@@ -68,7 +68,7 @@
         class="flex h-11 w-11 items-center justify-center rounded-2xl border border-white/30 bg-white/10 text-slate-200 transition-all duration-300 hover:-translate-y-1 hover:text-white"
         aria-label="Close navigation"
       >
-        <i class="fa-solid fa-xmark text-2xl"></i>
+        <i class="fa-solid fa-xmark text-2xl boop"></i>
       </button>
     </div>
     <ul class="mt-16 flex flex-1 flex-col items-center justify-center gap-8 text-center">
@@ -93,13 +93,13 @@
     </ul>
     <div class="mt-12 flex justify-center gap-4">
       <a href="https://github.com/ColinMcArthur85" class="social-btn" aria-label="GitHub">
-        <i class="fa-brands fa-github"></i>
+        <i class="fa-brands fa-github boop"></i>
       </a>
       <a href="https://www.linkedin.com" class="social-btn" aria-label="LinkedIn">
-        <i class="fa-brands fa-linkedin-in"></i>
+        <i class="fa-brands fa-linkedin-in boop"></i>
       </a>
       <a href="https://twitter.com" class="social-btn" aria-label="Twitter">
-        <i class="fa-brands fa-x-twitter"></i>
+        <i class="fa-brands fa-x-twitter boop"></i>
       </a>
     </div>
   </div>

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -1,6 +1,6 @@
 {
   "HTML": 5327,
-  "CSS": 4563,
+  "CSS": 4567,
   "SASS": 2299,
   "JavaScript": 950,
   "PHP": 0,

--- a/src/styles/tailwind/components/_cards.css
+++ b/src/styles/tailwind/components/_cards.css
@@ -1,10 +1,10 @@
 @layer components {
-  .card {
+  .primary-card {
     @apply relative overflow-hidden rounded-3xl border border-white/40 bg-white/70 p-8 shadow-xl backdrop-blur-2xl transition-all duration-500 dark:border-white/10 dark:bg-slate-900/60;
     isolation: isolate;
   }
 
-  .card::before {
+  .primary-card::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -15,22 +15,26 @@
     z-index: 0;
   }
 
-  .dark .card::before {
+  .dark .primary-card::before {
     background: linear-gradient(135deg, rgba(96, 165, 250, 0.16) 0%, rgba(15, 23, 42, 0.7) 55%, rgba(124, 58, 237, 0.22) 100%);
   }
 
-  .card:hover::before {
+  .primary-card:hover::before {
     opacity: 1;
   }
 
   /* Ensure card content sits above the gradient overlay */
-  .card > * {
+  .primary-card > * {
     position: relative;
     z-index: 1;
   }
 
-  .card:hover {
+  .primary-card:hover {
     @apply -translate-y-1 shadow-2xl;
+  }
+
+  .secondary-card {
+    @apply rounded-3xl border border-white/30 bg-white/80 shadow-xl backdrop-blur-lg transition-colors duration-500 dark:border-white/10 dark:bg-white/5;
   }
 
   .card-icon {


### PR DESCRIPTION
## Summary
- rename the shared card component to `primary-card` and add a new `secondary-card` style for static panels
- update the homepage and supporting pages to use the new classes, including the contact call-to-action cards
- add boop motion to every icon on the homepage and match the nav logo hover motion with the primary card lift

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc84894b9883268a2ca4593dfac40b