### PR TITLE
Fix scroll reveal visibility and module imports

### DIFF
--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -1,3 +1,7 @@
+// Import modules to ensure they register before we run initializers
+import "./modules/scroll-reveal.js";
+import "./modules/terminal-typing.js";
+
 (function (global) {
   function runInitialisers() {
     const modules = global.SiteFeatureModules || [];

--- a/src/styles/tailwind/utils/_animations.css
+++ b/src/styles/tailwind/utils/_animations.css
@@ -61,9 +61,20 @@
     animation: boop 450ms ease-in-out;
   }
 
-  [data-animate-on-scroll] {
+  /* Scroll Reveal System */
+  /* If JS is enabled, hide elements until they are ready/visible to avoid flicker/shift */
+  :root.js [data-animate-on-scroll] {
+    opacity: 0;
+    transform: translateY(1.5rem);
+    pointer-events: none;
+  }
+
+  /* When element is scrolled into view or is already in viewport */
+  /* Must match :root.js specificity from the hiding rule above */
+  :root.js [data-animate-on-scroll].is-visible {
     opacity: 1;
     transform: translateY(0);
+    pointer-events: auto;
   }
 
   [data-animate-on-scroll].is-reveal-ready {


### PR DESCRIPTION
## Summary

This PR fixes the issue where page content was hidden due to scroll reveal CSS conflicts.

### Changes

- **CSS Fix**: Added `:root.js` prefix to scroll reveal CSS rules to prevent content from being hidden when JavaScript hasn't loaded yet
- **Pointer Events**: Added `pointer-events: auto` to visible elements to ensure proper interactivity
- **Module Imports**: Imported `scroll-reveal` and `terminal-typing` modules at the top of `scripts.js` to ensure proper registration order

### Testing

- Verified that page content is visible on initial load
- Confirmed scroll reveal animations work correctly
- Checked that menu and all interactive elements are functional